### PR TITLE
Clean up the words by removing swear words

### DIFF
--- a/data/synonyms.tsv
+++ b/data/synonyms.tsv
@@ -13,7 +13,6 @@ reinforce	emphasize,boost,prove,verify,confirm,increase,underline,back,validate,
 guilty	responsible,liable,wrong,ashamed,convicted,criminal,sorry
 nj	newark,jersey,princeton,us,usa,camden,america,trenton,paterson
 jewelry	ice,rock,silver,earring,pendant,pin,glass,gem,jewel,accessory,clip,treasure,bead,costume,necklace,ring,jewellery,gemstone,bling,band,gold,stone,bracelet,ornament,decoration,brilliant
-garfield	
 h	letter,drug
 demos	demonstrations,protests
 purified	processed,natural,plain,refined,sterile,pure,filtered,clean,concentrated,pristine,tried,absolute,straight,fresh,neat,intact,snowy
@@ -23,16 +22,13 @@ dairy	farm
 relative	relation,aunt,related,sibling,corresponding,relational,family,father,uncle,cousin,kin,analogous,mother,folk
 imaginary	abstract,unreal,fantastic,invented,imagined,phantom,legendary,pretend,theoretical,fictional,hypothetical,ideal
 terrible	serious,severe,creepy,dread,dire,horrible,unfortunate,unpleasant,dangerous,disturbing,awful,scary,shocking,trying,awesome
-emulation	
 profitable	good,paid,worthwhile,fat,commercial,beneficial,practical,effective,juicy,paying,valuable,economic,rewarding,useful,successful,productive
 compassion	sympathy,grace,kindness,humanity,feeling,regret,sorrow,mercy
 gang	pack,squad,mob,tribe,battalion,party,association,crew,organization,team,brigade,syndicate,bunch,army,company,nest,clan,troop,ring,band
 layers	thickness,bed,row,slab,floor,loops,coat,blanket,sheet
 beers	loads,cocktails,wines,bottles,belts
-franklin	
 executives	committee,bureau,jury,department,ministry,directors,commissioners,legislature,administrators,presidents,administration,panel,authority,supervisors,executive,managers,management,board,presidency,cabinet
 policies	approaches,plans,methodologies,courses,morality,methods,integrity,procedures,programs,strategies
-iowa	
 extraordinary	wonderful,exceeding,some,peculiar,exceptional,noticeable,unprecedented,abnormal,fantastic,surprising,incredible,remarkable,striking,grand,weird,awful,tremendous,superior,curious,impressive,strange,uncommon,outstanding,amazing,great,unusual,one,odd,special,terrible,marvelous,singular,terrific,rare,unique,bizarre,particular
 jacking	boost,raise,hike
 wolf	coyote,lover,canine
@@ -47,13 +43,11 @@ bovine	relaxed,sober,cattle,cows,bos,confident,assured,centered,ox,relieved,deta
 flew	swept,winged
 ne	northeast
 remembering	recognition,connection,identification,memory,retrieval,association
-binoculars	
 corrosion	decay,deterioration,rust,erosion,decomposition
 wasting	symptom,corrosion,killing,crime,slaughter,extinction,warfare,deterioration,compassionate,impairment,weak,kindly,ill,decomposition,havoc,rot,destructive,humanitarian
 laminate	produce,create
 leaves	flee,start,retirement,fly,quit,drop,stop,retire,escapes,move,allow,surrender,escape,go,withdraw,vacation,needle,disappear,have,sheds,allowance,strands,authorization
 manufacture	fashion,make,create,form,produce,build,assemble,construct,frame,craft,complete
-ada	
 ceilings	bounds,ends,lines,limitations,walls,barriers,boundaries,caps,limits
 straight	dead,good,short,smooth,right,successive,directly,direct,away,consecutive,linear,solid,true,straightforward,decent
 artificial	unreal,arranged,painted,mechanical,dummy,colored,mock,near,hollow,pseudo,automatic,imitation,false,simulated,affected,fake,forced,manufactured,synthetic,assumed,cute,faux,empty,formal,theatrical,plastic,substitute,cardboard,bogus,staged
@@ -169,7 +163,6 @@ disappeared	away,invisible,melted,dissolved,absent,hidden,lost,removed
 inclined	glad,prepared,excited,given,partial,ready,willing,minded,fond,disposed,prone,apt
 listen	accept,observe,get,hear,attend,admit,hang,perceive
 flame	boy,bride,combustion,sweet,wife,girlfriend,girl,love,gal,ignition,mistress,lover,hon,spark,squeeze,light,boyfriend,flash,sweetheart,honey,beloved,darling,dear,flare,husband,burning,flaming,blaze,steady
-parkinson	
 hits	tags,clips,strikes,boxes,strokes,socks,bats,taps,pounds,belts,pushes,cracks,kicks,nails,whales,clocks
 votes	franchises,ballots
 circus	stadium,festival,park,bowl
@@ -218,7 +211,6 @@ economies	saving,conservation,providence
 none	never,complete,nobody,no,nothing,ill,hardly
 nuisance	tease,pain,pest,bother,headache
 gym	examination,ring,ballroom,performance,preparation,task,workout,movement,stadium,repetition,homework,training,auditorium,arena,conditioning,act,gallery,study,discipline,square,drill,spa,park,action,field,assignment,stage,chamber,activity,church,problem,lesson,test,theater,operation,lounge,drilling
-penguin	
 reconstruction	alteration,deformation,modification,fixture,overhaul,repair,reorganization,difference,remodeling,variation,distortion,regeneration,transition,replacement,rehabilitation,adjustment,transformation,displacement,makeover,shift,restoration,revision,fixing,redesign,change,rebuilding
 howto	guidebook,hardcover,catalogue,folio,textbook,catalog,handbook,softcover,encyclopedia,volume,dictionary,manual,paperback,text,tome,paper,book,primer,hardback
 minded	glad,willing,inclined,game,prepared,excited,disposed,oriented,ready,determined
@@ -260,9 +252,6 @@ winners	hero,champ,hits,champion,first,successes
 neighborhood	block,precinct,territory,zone,locality,proximity,section,region,matter,vicinity,neighbourhood,tune,district,parish,street,suburb,part,area,scenery
 inspired	divine,gifted,talented,imaginative,innovative,creative,clever,original
 existence	reality,animation,living,world,being,possibility,presence,continuation,activity,life,survival,eternity,existing,state,prevalence
-buddha	
-washable	
-finder	
 marines	service,soldiers,troop,force,rangers,navy,cavaliers,warriors,army,raiders
 terminals	stops,stations
 missile	bullet,ball,nose,arm,weapon,bomb,shell,cartridge,lead,rocket,pop,round,cap,shot,ammunition,load,slug
@@ -276,7 +265,6 @@ savings	possessions,fortune,effects,deposit,riches,reserve,fund,success,capital,
 variables	clusters,spheres,galaxies
 enroll	enter,obtain,join,draft,list,accept,engage,employ,admit,register,recruit
 representations	pictures,images,illustrations,drawings,photographs,image,views,sketches,portraits
-russell	
 tend	do,maintain,manage,watch,influence,run,lean,be,turn,favor,keep,go,feed,bear,protect,contribute
 banana	clown,herb,actor,comic
 headings	titles,headlines,banners,subtitles,heads,headers
@@ -293,7 +281,6 @@ lieu	part,behalf,function,office,place,position
 indoor	internal,inside,inward,interior,inner
 newspaper	weekly,feature,gazette,journal,rag,yearbook,magazine,editorial,strip,review,column,headline,newsletter,mag,serial,community,paper,bulletin,organ,book,edition,press,daily,sheet,periodical,zine
 rehearsal	practise,trial,reading,drill,practice,exercise,workout,preview
-creole	
 meadows	grounds,plain,prairie,pasture,fields,plains,plots,green,downs
 instructed	trained,skilled,learned,academic,informed,polished
 aboriginal	person,mortal,earliest,native,somebody,russian,original,filipino,local,indigenous,individual,someone,soul
@@ -341,11 +328,9 @@ sessions	meetings,discussion,gatherings,interviews,councils,clinics,conference,a
 drop	throw,collapse,slip,lower,cut,shoot,lose,deterioration,dip,hang,move,decline,end,stop,abandon,fell,fall,plunge,reduction,knock,release,dive,leave,dump,slide,sink,cancel,tumble,shed
 handful	few,scattering,couple
 atlas	tome,plan,paperback,outline,copy,drawing,catalogue,work,writing,text,textbook,booklet,essay,novel,brochure,graph,print,design,edition,column,directory,sketch,almanac,volume,thesaurus,picture,manual,fiction,dictionary,magazine,list,publication,album
-nurses	
 scholastic	collegiate,intellectual,learned,scholar,scholarly,educational,academic
 manufacturing	formation,shaping,manufacture,constructing,fabrication,framing,building,creating,producing,making,construction,forming,organizing
 shotgun	conserve,defend,bind,supervise,contingent,force,suppress,observe,require,pressure,limit,lucky,firearm,order,stray,make,ammunition,piece,hardware,move,demand,weapon,oversee,support,mortar,inhibit,sword,safeguard,drag,spot,accidental,cushion,cannon,urge,press,chance,gun,scattered,missile,arbitrary,impose,start,curb,random,exact,incidental,cause,shield,enforce,cruise,save,cover,charge,odd,shelter,bomb,patrol,inspect,rifle,restrict,secure,preserve,keep,pistol,drive,casual,knife,irregular,assure
-adaptive	
 charging	act,bidding,announcement,law,banning,storing,order,direction,statute,prohibition,judgment,regulation,rule,directive,instruction,injunction,packing,ruling,suppression
 stack	bucket,load,peck,pot,myriad,quantity,ton,yard,mess,much,pyramid,lot,heap,abundance,mass,volume,bundle,wealth,barrel,sight,deal,mountain,plenty,pack,chunk,dozen,hundred,loads,bunch,laden,pile,store
 acknowledges	accept,answer,agrees,announces,tells,notice,recognize,declare,confess,endorse,hail,reply,defend,allows,admits,agree,confirms,respond,reveals,grants,support,recognizes,address
@@ -386,17 +371,13 @@ partial	concerned,distorted,shaded,partisan,biased,unfair,influenced,incomplete,
 pops	taps,reports,cracks,crashes
 regulated	checked,governed,kept,coordinated,contained,measured,constrained,organized,controlled,supervised,standardized,managed,held,monitored,ruled,stopped,suppressed
 ppp	operation,surgery
-regent	
 historic	memorable,substantial,major,material,big,noteworthy,consequential,strategic,important,exceptional,outstanding,much,decisive,significant,famous,notable,meaningful,remarkable,extraordinary,distinguished,distinctive
 singing	karaoke
 fig	touch,pin,continental,ghost,darn,hint,beans,lick,figure,rap,little,ounce,bit,damn
 gis	brushes
 thousands	myriad,press,army,crowd,horde,sea,tons,trillion,flood,herd,overflow,lots,surplus,drove,flock,host,crush,mob,dozen,million,multitude,loads,score,legion,excess
-ang	
-oxford	
 irrigation	provision,supplying
 linking	merging,connecting,junction,combining,combination,coupling,union,connection,merger,synthesis,consolidation
-hamilton	
 fountain	commencement,spring,cradle,root,source,font,well,beginning,origin,reservoir,stream,construction
 being	possibility,mod,new,breathing,present,contemporary,presence,state,life,recent,current,animation,living,eternity,modern,existence,existing
 fins	dollars,tens,bucks,hundred,ones,chips,currencies,hundreds,cash,money,dough
@@ -441,14 +422,11 @@ german	jerry,hun,deutschland,germany,european
 dentistry	medicine
 handmade	homemade,crafted,handcrafted
 boston	ma,massachusetts
-loyola	
 discrepancies	disagreement,contrast,difference,variation,distinction,diversity,error,distance
 exterior	external,outer,outward,coating,outdoor,outside,skin,surface,position
 acknowledgement	mention,award,ribbon,medal,tribute,acknowledged,acceptance,citation
 advertisers	signs,symptoms,angels,runners
-astrology	
 trunk	bin,crate,coffin,locker,box,chest,stem,case,bag,compartment,torso,luggage
-internships	
 brighter	fiery,radiant,shiny,excellent,vivid,clear,glowing,brilliant,polished,sharp,happy,pleasant,flashing,smart,sparkling,colorful,lively,rich,glorious,mild,deep,burning,sunny,splendid,good,intense,fresh,flaming,shining,golden,lucent
 novice	newbie,pupil,apprentice,colt,student,recruit,beginner,trainee,virgin,rookie,learner,freshman
 attempted	sought,hoped,tried
@@ -457,7 +435,6 @@ preacher	clerk,clergy,clerical,bishop,divine,pastor,reverend,father,priest,missi
 naming	reference,assignment,comment,description,appointment,specification,choice,selection,notice,remark,nomination,notification,testimony,suggestion,option,proposal,decision,designation,recommendation,passport,certification,approval,recognition,indication,election,footnote
 exchanged	changed,traded,replaced,shifted,substituted,switched
 ce	ce
-photographers	
 computer	mainframe,site,host,crt,client,pc,keyboard,store,monitor,storage,floppy,peripheral,server,platform,processor,node,cpu,guest,website,memory,chip,hardware,bus,machine
 significantly	relatively,naturally,substantially,deeply,extensively,much,absolutely,considerably,positively,virtually,obviously,slightly,extremely,fully,typically,necessarily,exceptionally,moderately,pretty,quite,rather,originally,well,far,actually,fairly,remarkably,permanently,undoubtedly,very,thoroughly,partially,seriously,truly,wholly,utterly,reasonably,severely,completely,way,totally,somewhat,entirely,approximately,automatically,notably,really
 salute	recognise,recognize,hail,acknowledge,greeting,hello,bow,welcome,greet
@@ -468,9 +445,7 @@ pix	image,photo,portrait,snapshots,picture,photographs,snapshot,prints,photos,pr
 confrontation	competition,meeting,combat,battle,duel,contention,clash,encounter,crisis,showdown,conflict,war,struggle,contest,match,warfare,fight,dispute,opposition
 beginner	newbie,apprentice,student,prentice,recruit,trainee,cub,virgin,rookie,novice,learner,starter,freshman,initiate
 constrained	subordinate,mild,forced
-cambridge	
 monk	clerk,shepherd,clerical,bishop,divine,brother,preacher,pastor,archbishop,reverend,father,pope,dean,priest,missionary,minister
-broccoli	
 horrible	nightmare,scary,nasty,ugly,terrific,shocking,awful,cruel,grim,terrible
 getaway	pickup,recess,vacation,escape,holiday
 far	sore,desperately,especially,long,deeply,much,exceeding,that,super,absolutely,considerably,positively,distant,extremely,full,passing,exceptionally,jolly,such,utmost,farther,well,very,highly,remarkably,greatly,particularly,distance,so,thoroughly,removed,outlying,seriously,damned,too,deadly,deep,cracking,ever,extra,incredibly,badly,damn,utterly,real,remote,severely,completely,way,heavily,specially,totally,most,mighty,right,somewhat,bone,further,entirely,significantly,almighty,wicked,awful,terribly,cold,really
@@ -509,8 +484,6 @@ scoring	rating,filing,milling,grading,marking,grazing
 teaches	lessons,show,instruct,tutor,explain,schools,coach,demonstrate,lecture,prepare,trains,direct,coaches,develop,train,advise,tutors
 roses	picnic,nothing,snap,cake,breeze
 thoughts	feeling,debates,heart,opinion,thinking,eye,judgment,view,considerations,will,mood,head,attention,determination,accounts,attitude,sentiment,wish,studies,desire,reflections
-lipitor	
-imo	
 budgetary	fund,deposit,monetary,pool,savings,economic,financial,industrial,account,kitty,fiscal,collection,commercial
 undertaken	accepted,born,embraced,assumed,borne,adopted
 grandparents	sibling,mother,aunt,father,uncle,folk,cousin
@@ -534,7 +507,6 @@ piles	hills,luxury,stacks,mountains,wealth,layers,scores,quantity,torrent,tons,d
 rose	enlarged,spread,accumulated,accelerated,expanded,rosa,climbed,jumped,mounted,bush,increased,multiplied,gained,hip
 concern	corporation,apply,advert,business,hold,involvement,firm,relate,association,touch,involve,matter,refer,trouble,agency,company,enterprise,affect,bother,burden,care,establishment,consideration,regard,interest,center,house,worry
 positives	pros,approvals
-conrad	
 lows	bays
 cutter	gig,sword,ship,blade,vessel,tender,craft,submarine,corvette,knife,yacht
 basement	cellar,floor,level,storage,story,vault,storey
@@ -564,7 +536,6 @@ wizards	witches,genius,shark
 heterogeneous	diversified,chaotic,different,motley,diverse,miscellaneous,varied,assorted,messy,eclectic,mixed
 condom	rubber,preventive,safety,safe
 maintains	keep,finance,hold,declare,control,provide,protect,preserve,emphasize,say,saves,sustain,insist,manage,renew,continue,defend,stress,preserves,retain,support,advocate,protects
-howe	
 inevitable	possible,sure,imminent,definite,probable,certain,necessary
 rabbits	sheep,fleece,hide,fisher,skin,crocodile,beaver,otter,fox,leather,badger,hare,fur,seal,bunny
 examiners	observers,researchers,inspectors
@@ -601,7 +572,6 @@ demo	show,illustration,expression,display,album,rally,disk,protest,demonstration
 volt	kv,mv
 comfort	sympathy,relieve,cheer,happiness,enjoyment,pleasure,refresh,warmth,relaxation,help,encourage,console,compassion,encouragement,luxury,satisfaction,delight,support,convenience,relief
 moonlight	sunlight,fluorescence,reflection,light,glow,daylight,moon,sunshine,stream,sparkle,aurora,illumination,beam,glitter,blaze,flash
-southwestern	
 loud	heavy,clarion,audible,strong,big,rude,shouted,volume,intense,ringing,piercing,powerful,noisy,intensity
 abandon	surrender,reject,waive,quit,yield,ditch,discard,leave,toss,deliver,desert,dispose,stop,withdraw,dump
 sharply	carefully,strongly,sharp,clearly
@@ -612,7 +582,6 @@ adoption	enactment,ratification,maintenance,approving,acceptance,approval,embrac
 hf	metal
 artistic	decorative,musical,cultural,creative,imaginative,aesthetic,dramatic
 stretch	swell,draw,radius,fill,expand,pull,sheet,territory,cover,breadth,reach,extent,open,go,sweep,strain,be,waste,tract,area,spread,expansion,length,distance,region,grow,field,plain,spell,develop,bridge,span,run
-sofas	
 cole	cabbage
 exclusively	alone,primarily,completely,entirely,mainly,only,solely,principally,just,purely,largely,wholly,mostly,predominantly,simply
 bm	movement
@@ -633,7 +602,6 @@ wings	unit,way,teams,sides,means,branch,bodies,circle,side,blocks,group,parties,
 reminder	token,hint,souvenir,memorial,monument,remembrance,tribute,suggestion,experience,sign,gesture,expression,indication
 thereafter	subsequently,afterwards,after,then,soon,later
 avoiding	eliminating,shaking,preventing,excluding
-tunisia	
 excellence	merit,distinction,virtue,importance,refinement,quality,purity,perfection,civilization
 solicitor	attorney,counselor
 noisy	loud
@@ -716,7 +684,6 @@ expeditions	excursions,flights,cruises,trips,tours,travels,rides,journeys
 mushrooms	balloons,spreads,increases,rises,mounts,expands,jumps,gains
 vii	seven,digit,figure
 chemical	flux,pesticide,explosive,compound,fraction,material,stuff,intermediate,fertilizer,carrier,product
-cf	
 beard	imperial,brave,encounter,fight,dare,face,withstand,breast,beaver,confront
 alternatives	choices,substitute,picks,option,liberties,opportunity,ways,preferences,elections,selections,options
 envelopes	hides,plates,shields,skins,coatings,cassettes,houses,packages,mails
@@ -727,7 +694,6 @@ dosage	shot,drug,lot,application,quantity,measure,dose,remedy,pill,measurement,p
 opponent	enemy,match,rival,candidate,opposition,player,competitor,challenger
 relation	foundation,possession,ownership,commerce,connection,opposition,affinity,position,dealings,constituent,association,change,comparison,component,interaction,relationship,part,function,portion,control,abstraction
 cultured	civil,intelligent,polished,polite,educated,cerebral,accomplished,cultivated,knowledgeable,sophisticated,tolerant,cosmopolitan,refined,scholarly
-vanderbilt	
 baroque	steep,endless,excessive,insane,extreme,fancy,infinite,stiff
 foundations	establishment,endowment,infrastructure,institutions,charity,institutes,corporation,association,company,corporations,society,base,institute,charities,authority,establishments,organization,support,groups
 voluntary	discretionary,unpaid,willing,elective,volunteer,intended,optional,spontaneous,conscious
@@ -745,7 +711,6 @@ rounding	rolling,bend,loop
 alot	considerably,highly,extensively,greatly,broadly,much,significantly,utterly,largely
 sportswear	ensemble,outerwear,couture,dress,costume,underwear
 kingdom	discipline,department,game,territory,business,arena,domain,realm,circle,province,element,walk,land,orbit,field,precinct,sphere,terrain,area,front,specialty,study
-asbestos	
 blaze	explosion,flash,outbreak,blast,flare,flame,beam,flush,storm,frenzy,gale,sparkle,glow,fit,shine,explode,burst
 eff	love,pair,mate,neck,bang,jazz,have,take,couple,know,screw,bed
 pens	coolers,cells,joints,cages,prisons,cans,tanks
@@ -759,7 +724,6 @@ uniform	reliable,homogeneous,systematic,gown,clothing,suit,wear,dress,costume,ri
 stars	spheres,issue,chance,future,consequence,effect,circumstance,destiny,clusters,galaxies,suns,outcome
 cooperative	communal,collaborative,joint,multiple,reciprocal,mutual,coordinated,united,collective,supportive,combined,responsive,public,shared,useful
 separate	other,sovereign,various,different,particular,separated,break,divorce,isolated,unique,separation,individual,distinct,respective,single,disconnect,divide,autonomous,independent,diverse,divided,free,split,detached,apart,discrete,leave
-ecological	
 pump	duck,tap,swing,handle,send,jerk,rock,manage,shake,bob,draw,nod,pour,drain,supply,push
 celebs	personalities,heroes,names,stars,celebrities,figures
 aug	august
@@ -772,7 +736,6 @@ microwave	stove,bake,toaster,cooker,oven
 peers	board,lords,gentlemen,knights,cohort,tribunal,princes
 lateral	left,side
 circuit	link,relay,district,perimeter,bypass,loop,tour,diameter,tube,resistor,wiring,compass,resistance,course,bridge,radius,capacitor,lap,route,short
-pathology	
 unauthorized	mandate,authorization,inappropriate,unlawful,unacceptable,improper,illicit,forbidden,unofficial,wrongful,authorisation,excluded,prohibited,illegal
 stove	boiler,range,microwave,toaster,oven,cooker,heater
 wished	desired,imposed,needed,forced
@@ -784,7 +747,6 @@ aside	engaged,out,elsewhere,alone,hence,apart,reserved,separately,away,off,down
 desserts	goodies,bits,sweets,treats
 billings	adverts,bulletins,bills,signs,handouts,advertisements,brochures,declarations,postings,reports,spots,notices,messages,notifications,promotions,flyers,broadcasts,commercials,communications,releases,posters,ads,announcements,words
 afford	swing,provide,allow,get,go,manage,offer,finance,spend,purchase,cover,grant,acquire,take,obtain
-dewey	
 roommate	fellow,half,companion,equal,ally,mate,partner,peer,cohort,colleague,friend,buddy,affiliate,pal,intimate,associate
 build	manufacture,expand,form,customize,evolve,create,erect,found,lock,establish,produce,construct,frame,base,customise,begin,start,piece,develop,make,boost,design,enlarge,raise,rebuild,strengthen,rear,assemble,improve
 otter	badger,sheep,hide,skin,fleece,beaver,seal,fisher,crocodile,fur,rabbit,leather,fox
@@ -839,13 +801,11 @@ notified	published,posted,proclaimed,declared,announced,advertised,advised,infor
 dramas	plays,musicals,opera,works,comedies
 readings	versions,accounts,performances,interpretations
 arose	rose,woke
-sl	
 audiences	cult,market,crowd,gathering,following,congregation,gallery,public
 palette	compass,range,scope,pallet,orbit
 sins	offenses,crimes,violations,errors,debts,offences
 studs	dolls,hunks,fox,dishes
 embroidered	beautiful,elegant,distorted,fabricated,enlarged,sparkling,excessive,abstract,magnificent,stretched,fancy,false,padded,baroque
-insomnia	
 corrections	alterations,amendments,modifications
 vertex	top,meridian,roof,height,prime,sum,summit,acme,climax,extreme,head,noon,peak,zenith,apex,flower,crown,pinnacle,tip,crest
 ultra	extreme,radical,revolutionary,violent
@@ -853,8 +813,6 @@ gaming	bet,throw,sport,betting,game,recreation,match,vice,play,gambling,diversio
 brussels	belgium
 graphic	picture,illustration,figure,drawing,art,caption,graphical,plate,diagram,artwork,image,visual
 nifty	fab,quality,top,groovy,excellent,beautiful,brave,cool,great,prime,marvelous,neat,banner,mean,bumper,stylish,immense,famous,swell,splendid,decent,prize,superior,dynamite,wizard,better,wonderful,noble,special,divine,fabulous,sterling,fine,choice,cracking,fantastic,terrific,keen,righteous,superb,radical,good,heavenly,hot,slick,classic,awesome,exceptional,grand,stellar,lovely
-edward	
-aix	
 strengthened	loose,sturdy,powerful,secured,fit,hard,assisted,enjoyable,appropriate,healthy,cozy,sound,pleasant,covered,hale,easy,athletic,pleased,happy,husky,convenient,reinforced,relaxed,satisfying,energetic,robust,useful,recovered,trim,warm,vigorous,mighty,protected,tough,soft
 eats	bread,food,chow,fare,supplies,chuck,provisions,meat,meal,table
 clutch	variety,collar,bunch,set,grouping,block,suite,claw,lot,knot,grip,mixture,array,collection,package,grasp,nail,take,batch,battery,accumulation,cluster,grab,band,cop,arrest,catch,series,get,bank,group,seize,rack,capture,parcel,aggregation,assortment
@@ -875,7 +833,6 @@ anymore	presently,here,nowadays,currently,today,now
 pragmatic	sober,efficient,realistic,sensible,practical,logical,rational,reasonable
 local	provincial,domestic,indigenous,native,regional
 manure	stool,dropping,compost,waste,sewage,dirt,soil,organic
-microbiology	
 genus	variety,classification,sort,set,grade,form,category,generation,league,family,section,class,species,tier,breed,division,kind,bracket,group,type
 harmonic	balanced,pleasing,symmetric,artistic,elegant,aesthetic,sympathetic,graceful
 inc	rise,proceeds,wage,partial,earnings,compensation,revenue,development,expansion,royalty,gain,inflation,profit,pay,merger,deficient,salary,interest,cash,boost,raise,inadequate,hike,increment,surge,lacking,insufficient
@@ -887,10 +844,8 @@ defendants	offenders,fish,criminals,suspects,fishes,detainees,principals,accused
 align	sort,square,arrange,go,adjust,organize,fit,correspond,check,order,adapt,address,match,array,merge,combine,true,proportion,accord,integrate,coordinate,balance,unite,accommodate,conform,regulate,cooperate,agree,even,connect,focus,associate
 holders	owners,purchaser,partner,buyer
 comb	rake,rifle,examine,device,troll,scan,tooth,investigate,survey,locate,search,inspect,explore,find
-rhino	
 additions	extensions,wings
 broke	poor,depressed,ruined,busted,needy,deprived,bust
-hess	
 ave	farewell
 nomination	picking,placement,assignment,station,selection,recommendation,gig,designation,position,authorization,destination,office,spot,job,naming,choosing,election,choice,suggestion,proposal,delegation,commission,situation
 illness	attack,collapse,flu,sickness,disability,bug,disease,disorder,disturbance,ill,syndrome,infection,virus,seizure,breakdown,condition,growth,fever
@@ -905,14 +860,12 @@ conferences	symposium,assemblies,panels,organization,meeting,league,meetings,gat
 attachments	respects,desires,apparatus,material,passions,loves,regards,machinery,furnishings,furniture
 closures	finishes,stops,stays,arrests,checks,conclusions,closes,ends
 fined	put,imposed,assessed,charged
-hypertension	
 singles	individuals
 competence	ability,faculty,savvy,competency,skill,capability,talent,expertise,suitability,proficiency,qualification,capacity,fitness
 verbal	rhetoric,linguistic
 suggests	advocate,promise,represent,advise,indicates,offer,refer,hint,refers,recommend,submit,implies,put,point,propose,hints,indicate
 disposal	dumping,destruction,removal,allocation,transfer,demolition,distribution,disposition,clearance
 roman	roma,italian,classic
-spying	
 formulate	couch,articulate,prepare,evolve,define,suppose,forge,acquire,draft,map,mature,phrase,word,state,put,express,develop,say,describe,summarize,translate
 affiliation	dealings,collaboration,merger,cooperation,union,relation,connection,alliance,association,interaction,relationship,solidarity,partnership,liaison
 copper	flaming,police,iron,cu,glowing,force,inspector,detective,troops,bull,squad,cardinal,coral,man,bobby,sheriff,officer,metal,brass,conductor,cop,maroon,crimson,rose,platinum,wine,gold,mineral
@@ -933,23 +886,18 @@ cafeteria	cafe,grill,restaurant,tavern,diner
 tara	ireland
 autonomous	independent,democratic,sovereign,separate
 shortage	poverty,deficiency,deficit,lack,pinch,failure,absence,crunch,weakness,drought
-decks	
 odd	miscellaneous,lone,alone,unusual,different,single,solitary,only,singular,sole
 wall	threshold,hedge,obstacle,block,chain,attic,hall,side,door,header,surface,firewall,arch,partition,dam,course,coping,pane,row,fence,barrier,pier,cope,building,room,screen,bar
 albanian	albania
 guided	led,regulated,engineered,showed,managed,negotiated,educated,accompanied,directed,trained,handled,supervised,taught,fulfilled
 jar	encounter,hit,crash,smash,knock,bump,slap,can,contact,vessel,basin,kick,mouth,bottle,punch,strike,collision,blow,shock,slam,pot,buffet,pounding,urn,lid,impact,vase
 mains	continents
-lambda	
 protections	shields,guards,walls,weapons,screens,wards,safeguards,defenses,securities
 auditory	heard,audible,acoustic
 databases	components,elements,constituents,facts,details,items,members,articles,ingredients,data,information
 yep	positively,fine,okay,aye,yeah,yes,alright,ay,yea,yo,ok
 maintaining	protecting,plea,idea,continuity,assertion,discussion,claim,position,saving,belief,thesis,running,opinion,preservation,preserving,chronic,performing,extension,enduring,explanation,lasting,restoring,durable,defending,hypothesis
 condos	apartments,salons,studios,suites,flats,wings,efficiencies,condominiums
-vaccination	
-pluto	
-afro	
 postscript	finale,letter,finish,closing,ps,appendix,footnote,notation,conclusion,aftermath,close,annotation,climax,ending
 warehouse	storage,depot,repository,bank,store,container,magazine
 surfaces	top,appear,faces,side,skins,emerge,fronts,level,tops,skin,face,area,arise,shells,exterior
@@ -978,7 +926,6 @@ prepared	inclined,arranged,up,go,willing,equipped,spread,able,adapted,processed,
 domain	discipline,department,game,territory,business,arena,realm,environment,circle,responsibility,province,element,walk,preserve,land,orbit,field,subject,kingdom,precinct,sphere,terrain,area,front,line,specialty,study
 phones	calls,telephones
 authorization	mandate,consent,allowance,clearance,permission,accreditation,endorsement,authorised,permit,authorisation,warrant,sanction,license,signature,authorized,authority,unauthorized,granting,licence,approval,instrument,leave
-futures	
 pumped	greedy,engaged,happy,wired,anxious,interested,eager,crazy,keen,great,hungry,willing,avid,nuts,enthusiastic,excited,ready,tense
 poem	epic,song,lay,writing,ballad,lyric,composition,verse,poetry
 generation	era,invention,construction,rise,period,development,day,creation,peers,cohort,people,innovation,production,formation,time,genesis
@@ -990,7 +937,6 @@ disabled	down,blind,sick,challenged,deaf,broken,handicapped,exceptional,impaired
 highways	roads,pike,avenues,arteries,drives,lanes,routes,streets,ways
 tab	check,record,capsule,dosage,receipt,statement,dose,account,pill,bill,invoice,document,price,rate
 ash	residue,bake,light,grey,char,burn,torch,golden,cook,blonde,fire,dusty
-lambert	
 monroe	la,louisiana
 wand	staff
 favorites	darling,choice,treasures,pick,pets,preferences,speeds,idol
@@ -1007,10 +953,8 @@ covering	shield,hood,mask,mantle,curtain,wraps,cover,screening,cope,veil,blanket
 packets	containers,packs,sacks,packages,boxes,bags,parcels,bundles
 clad	surround,coated,wrap,dress,suited,face,array,apparel,decorated,dressed
 sketches	chart,copy,description,figures,picture,blueprint,cartoon,summary,outlines,drawings,paint,illustrations,images,representations,piece,illustration,cartoons,painting,account,portraits,chalk,version
-hours	
 pollutant	contamination,pollution,poison,waste,sludge,defect
 blitz	attack,tide,bombing,hail,storm,raid,flood,assault,offensive,shower,torrent
-apron	
 reset	limit,define,determine,remove,specify,fix,transformed
 clouds	risk,possibility,instability,emergency,exposure,crisis,menace,vulnerability,shadows,threat,probability,uncertainty
 superb	fab,quality,excellent,groovy,top,beautiful,brave,cool,great,prime,marvelous,neat,banner,gorgeous,immense,famous,swell,breathtaking,splendid,decent,dynamite,prize,elegant,superior,noble,wonderful,outstanding,sublime,divine,fabulous,solid,brilliant,nifty,fine,glorious,sterling,frontline,choice,cracking,fantastic,keen,stunning,terrific,good,heavenly,hot,magnificent,slick,classic,exquisite,awesome,exceptional,grand,stellar,lovely,best
@@ -1023,7 +967,6 @@ embodiment	genius,expression,model,symbol,realization,incorporation,abstract,ima
 pearls	strand,jewelry,prizes,jewels,treasures,catches,blessings,necklace,pendant,gems
 patent	concession,document,copyright,label,trademark,charter,protection,brand,papers,license,privilege
 patrons	market,community,customers,crowd,people,population,country,buyers,clients,public,everyone,gathering,nation,society,users,consumers,guests,audience,congregation,gallery,constituency
-testosterone	
 forecasts	signs,casts,predictions
 geographical	geological,geographic
 jerking	fool,motion,shaking,lug,flop,idiot,movement,jerk,bump,move,pulling,wrench,thrust,bounce
@@ -1045,11 +988,9 @@ shakes	tension,sensitivity,concern,anger,misery,discomfort,rocks,uncertainty,str
 scandinavia	sweden,norway,scandinavian,europe,denmark
 panorama	picture,outlook,landscape,perspective,image,scenery,vista,view
 leading	prima,popular,first,famous,paramount,capital,premier,best,principal,outstanding,starring,prominent,prior,dominant,key,stellar,central,noted,greatest,foremost,master,distinguished,chief,sovereign,main,great,supreme,cardinal,top,major,big,primary,highest
-peso	
 spas	gyms
 mode	situation,style,system,status,way,manner,response,touch,signature,form,process,fashion,approach,vein,quality,posture,technique,tone,property,lifestyle,wise,procedure,setup,method,mechanism,fit,condition
 islands	reef,isles,isle,peninsula
-murray	
 parole	immunity,exemption,forgiveness,amnesty,secret,password,pardon,word
 boss	captain,commander,superintendent,principal,foreman,manager,executive,leader,owner,supervisor,master,chief,opponent,head,employer,lord,administrator,president,governor,director
 bloggers	columnists,writers,journalists,pens,reporters,authors
@@ -1065,7 +1006,6 @@ uniforms	arrays,clothes,tricks,dress,robe,suits,gown,suit,costume,dresses
 woody	crate,auto,hybrid,bus,intermediate,coach,sedan,convertible,limousine,motor,mini,car,hatchback,wagon,van,compact,wheels,automobile,machine,suv,coupe
 fulfillment	realization,prosecution,achievement,enactment,management,administration,accomplishment,attainment,perfection,handling,application,performance,implementation,execution
 pleasure	enjoyment,desire,purpose,content,comfort,satisfaction,amusement,happiness,luxury,bliss,feeling,thrill,joy,hobby,delight
-labrador	
 freak	mutation,monster,outstanding,variation,rare,nut,anomaly,singular,addict,noticeable,extraordinary,remarkable,peculiar,buff,mutant,uncommon,incredible,geek,exceptional,odd,unique,unusual,enthusiast,exceeding,abnormal
 pill	capsule,cap,medication,dose,medicine,drug,thing,tablet
 sorts	genres,descriptions,types,varieties,breeds,likes,classes,kinds,stripes,species,manners
@@ -1076,7 +1016,6 @@ adequately	fine,correctly,happily,sufficiently,rightly,appropriately,okay,good,n
 suppression	discipline,elimination,possession,restraint,inhibition,discretion,control,constraint,reserve
 translates	transform,summarizes,render,convert,turn,alter,put
 relate	think,associate,reveal,concern,affect,describe,identify,detail,remember,link,disclose,mean,compare,click,apply,connect,refer,present,assign,bond
-hugo	
 tasmania	australia,hobart
 inaccuracies	errors,faults,trips,mistakes,bricks
 frankly	actually,absolutely,really,honestly,truly,positively,certainly,indeed
@@ -1100,7 +1039,6 @@ implication	deduction,suggestion,indication,meaning,hint,significance,cue,conclu
 lf	audio,rate,attendance,infrared
 installer	receive,initiate,seat,invest
 convergence	combining,consolidation,occurrence,encounter,merging,conjunction,meeting,combination,linking,connecting,happening
-mus	
 religion	prayer,communion,ritual,analogy,cult,morality,belief,church,theology,faith,myth,doctrine,creed,persuasion,sect,mythology,christianity,buddhism,spirituality
 group	multitude,array,organize,variety,race,system,edition,kingdom,community,parcel,gang,mixture,crowd,assortment,band,arrangement,arrange,lot,collection,package,clutch,people,grouping,series,association,cluster,club,mankind,abstraction,humanity,humans,man,battery,halogen,cloud,population,circuit,accumulation,suite,organization,subgroup,batch,troop,world,class,gather,bank,bunch,meet,scheme,society,party,faction,block,set,company,masses,mass,body
 gamer	sport,opponent,tournament,sweepstakes,competition,bout,championship,contest,competitor,meet,participant,event,battle,match
@@ -1137,7 +1075,6 @@ fulfil	accomplish,action,complete,finish,dispatch,redeem,keep,do,fulfill,perform
 alone	entirely,only,separately,independently,individually,solely,exclusively
 cliffs	scars
 renovation	repairing,repair,renaissance,renewal,reclamation,improvement,recovery,fixing,reconstruction,revival,remodeling,redevelopment,resurrection,upgrade,regeneration,overhaul,restoration,rehabilitation,rehab
-hungarian	
 bone	tooth,os,disposition,leaning,affinity,collagen,matrix,tendency,preference,costa,jaw,nasal,skull,affection,turn,bent,devices,marrow,rib,genius,impulse,horn,bias,appetite,socket,addiction,talent,gift
 vice	ill,bad,sin,corruption,evil
 ordinance	rule,statute,regulation,bill,constitution,enactment,amendment,prohibition,act,law,legislation
@@ -1192,7 +1129,6 @@ flush	colour,rinse,warm,burn,color,tanned,pink,glowing,red,blush,wash,glow,brown
 institute	organize,team,league,college,club,chamber,found,fraternity,association,plant,chapter,initiate,institution,council,fix,install,collective,congress,guild,nominate,society,name,introduce,community,fellowship,brotherhood,board,organization,group,constitute,pioneer,appoint,establish,launch,create,consortium
 robot	mechanism
 cloud	steam,fog,mantle,eclipse,mushroom,shadow,vapor,muddy,coma,obscure,veil,puzzle,aerosol,mist,darkness,dim,smoke,haze,shower,puff,blur
-mps	
 allergies	downs,hates
 gemstone	gem,stone,ornament,rock,jewel,crystal,jewellery,bling,bead,brilliant,jewelry
 http	field,study,subject,discipline
@@ -1256,8 +1192,6 @@ academia	domain,world,university
 prerequisites	requisite,must,requirements,essential,qualification,needs,essentials,conditions,requirement
 festivals	feast,gala,celebrations,holiday,anniversary,competition,fair
 workstation	factory,bureau,facility,center,shop,department,agency,building,suite,store,room,laptop
-milan	
-ev	
 kyoto	japan
 rookie	freshman,novice,student,newbie,initiate,cub,recruit,virgin,beginner,apprentice,colt
 compose	contain,produce,frame,design,comprise,prepare,arrange,collect,cast,draft,build,make,pen,constitute,represent,formulate,write,be,construct,craft,form
@@ -1281,10 +1215,8 @@ sampled	examined,explored,investigated,tested
 ta	metal
 pedigree	origin,side,birth,folk,breeding,family,stock,genealogy,ancestry,blood,lineage,strain,line,extraction,sept,descent
 joining	contiguous,connection,conjunction,company,friendship,interest,linked,linkage,joined,collection,touching,association,union,cooperative,agreement,ownership,reciprocal,close,junction,approximation,society,crossing,closest,assortment,corporation,tie,channel,network,coordinated,firm,link,assistance,relationship,hit,attachment,united,organization,connected,adjoining,adjacent,encounter,cooperation,element,partnership,sharing,terminal,interconnection,attached,neighboring,intersection,contact,nearest,business,affiliation,convergence,connecting
-afl	
 retiring	withdrawn,preceding,backward,outgoing,shy,reserved,lone,modest
 mystery	matter,riddle,problem,challenge,thriller,secrecy,secret,question,why,puzzle
-yi	
 entries	doors,halls
 linkages	correlation,link,connection,relationship,liaison,similarity,bearing,association,relation,affinity
 lecture	instruction,rag,blame,fault,speech,teach,address,mock,discourse,attack,rate,score,talk,jaw
@@ -1292,7 +1224,6 @@ suits	closet,trunk,complaints,proceedings,apparel,lawsuits,actions,dresser
 mol	operative,spy,mole,agent,asset,undercover
 stepping	walking,wandering,marching,padding
 portions	lot,piece,chunk,allocation,excerpt,part,chances,quantity,segment,serving,section,fraction,circumstances,fragment,lots
-us	
 duck	guy,baby,thing,cookie,specimen,egg,being,party,life,bow,mortal,devil,head,dodge,personality,scout,soul,human,fish,escape,face,dive,character,person,creature,bird,sort,body,customer,bend,man,individual
 whistle	zip,go
 folds	doubles,closes
@@ -1301,9 +1232,7 @@ does	complete,play,quit,produce,achieve,bear,determine,accomplish,cover,satisfie
 cues	signs,hint,clue,hints,clues,indications,leads,signals,suggestion,ideas,suggestions
 revise	compare,review,alter,vary,cut,change,modify,amend,rewrite,overhaul,remake,update,improve,transform,develop,upgrade
 indication	gesture,lead,warning,expression,proof,sign,symptom,shadow,clue,signal,print,suggestion,implication,trace,cue,reminder,evidence,predecessor,explanation,mark,glimpse,idea,herald,hint,precursor,suspicion,communication,smoke
-saratoga	
 reusable	useful,fit,feasible,practicable,viable,functional,available,usable,relevant
-vatican	
 nv	us,colorado,nevada,reno,southwest,america,usa
 visor	bill,helmet,peak,shade
 massive	imposing,heavy,extensive,substantial,impressive,grand,huge,gigantic,enormous,large,mammoth,big,great,vast,immense,tremendous
@@ -1313,7 +1242,6 @@ timely	proper,appropriate,meet,prompt,relative,pertinent,apt,expected,fortunate,
 accomplished	cultured,cerebral,proficient,complete,refined,sophisticated,learned,polished,civil,realised,scholarly,talented,polite,educated,cultivated,realized,gifted
 momma	mama,mother,mummy,ma,mom,mum,mommy
 notification	ad,brochure,advert,bulletin,message,advertising,posting,advertisement,notice,report,announcement,release,warning
-hiv	
 determinations	rulings,decisions,opinions,resolutions,awards,conclusions,findings,judgments
 tested	troubled,tried,bothered,tortured,certified,proved,distressed,disturbed,angry,approved,frustrated,upset,annoyed
 memoirs	account,record,biographies,annals,biography,lives,remembrance,story,relation,tale,bios
@@ -1335,7 +1263,6 @@ plan	program,organize,plot,strategy,design,projection,method,arrange,docket,way,
 maple	wood
 comes	approaches,advances,enters
 spanning	scaling,assessing,measuring,weighing
-nu	
 rests	balances,remains,residues,fragments
 buck	jay,withstand,endeavor,dude,oppose,strive,beau
 implant	lodge,root,fix,breed,drive,sink,nest,enter,plant,introduce,pot,insert
@@ -1352,11 +1279,9 @@ periodic	periodical,hourly,seasonal,daily,nightly,continual,occasional,routine,r
 gcse	grade,level
 leaks	shouts,bolts
 syrup	corn,emotion
-southeast	
 await	attend,expect,predict,look,wait,stay,anticipate
 plush	concentrated,rich,elegant,strong,luxury,deluxe,full,robust,potent,big,lush,muscular
 erected	raised,lifted,pitched,elevated,supported
-mba	
 earth	sand,surface,shore,mud,world,dust,clay,air,gravel,planet,ground,coast,land,universe,turf,globe,earth,atmosphere,terrain,dirt,sky
 perceived	anticipated,viewed,heard,recognized,felt,noted,noticed,saw,expected,scented,realized
 hall	gallery,theater,gym,ceiling,lobby,ballroom,entry,auditorium,lounge,chamber,flooring,church,corridor,room,floor,arena,entrance
@@ -1430,16 +1355,13 @@ bosses	executives,masters,leaders,administrators,chiefs,managers,administration,
 elk	deer
 including	besides,plus,beyond,beside
 fractions	half,chunk,pieces,portion,bits,fragments,portions,scraps,ratio
-liverpool	
 balls	beads,circles,globes,hunks,rings,spheres,eggs
 disconnect	isolate,part,separate,resolve,divide,divorce,pull,split
 cushions	buffers,pads,shields
 increasing	raising,rising,swelling,strengthening,maximizing,progressive,enhancing,expanding,growing,developing,extending
 constraint	pressure,restraint,discipline,reserve,curb,confinement,restriction,discretion,suppression,inhibition
-bisexual	
 anglican	protestant
 theory	suspicion,thesis,position,code,assumption,system,ideology,idea,philosophy,provision,plan,explanation,proposition,hypothesis,possibility,understanding,suggestion,law,impression,doctrine,argument,premise,proposal,rationale,concept,guess,theorem,scheme,speculation,approach,method
-winery	
 paragraph	wording,component,reading,text,information,clause,piece,idea,provision,specification,sentence,verse,quotation,portion,chapter,content,requirement,transition,section,item,detail,article,theme,document,feature,passage,thing,element
 blur	cloud,dim,fog,obscure,representation,muddy
 glasses	sunglasses,bridge,frame,specs,shades,goggles
@@ -1468,14 +1390,12 @@ forgotten	neglected,void,abandoned,discarded,vacant,empty,ignored,rejected
 wherein	thus,where,how
 merely	barely,simply,hardly,only,purely,quite,but,solely,just
 weblogs	blogs,diaries
-kern	
 biblical	sacred,spiritual,religious,holy,theological,blessed
 pleasing	welcome,darling,pleasant,fabulous,comfortable,humorous,desirable,entertaining,fascinating,satisfying,engaging,happy,attractive,easy,charming,nice,blessed,favorable,pretty,dreamy,fab,beautiful,grateful,enjoyable,delicious,sweet,jolly,delightful,good,heavenly,satisfactory,tasty,soothing,amusing
 europe	scandinavia,spain,switzerland,portugal,bulgaria,continent,netherlands,austria,monaco,belgium,iceland,romania,gibraltar,west,poland,finland,hungary,nederland,england,luxembourg,ukraine,greece,france,estonia,andorra,holland,germany,belarus,scotland,liechtenstein,slovakia,moldova,ireland,latvia,deutschland,italy
 incorrect	erroneous,flawed,inappropriate,wrong,improper,inaccurate,confused,false,mistaken,correctness,faulty
 hooks	knees,hacks,switches,bats,hits,clips,stripes,belts,boxes,socks,hand,beats,cracks,hands,picks,pounds,blows,strokes,kicks,paw,swings
 nuts	crackers,odd,bats,psycho,depressed,mad,ballistic,wacky,paranoid,foolish,obsessed,cracked,strange,insane,disturbed,crazy,buggy,unreasonable,off,mental
-poets	
 handset	phone,grip,hold,telephone,handle
 crochet	knit,introduce,snake,patch,ornament,decoration,stitch,overcast,finish,quilting,create,compose,incorporate,mesh,sew,spin,fuse,hook,bind,quilt,construct,weave,tapestry,fold,lace,loop,unite,twist
 answered	return,returned,replied,solve,responded,resolve,clarify,do,acknowledge,commented,claim,deny,explain,argue,respond,defend,meet,say
@@ -1484,7 +1404,6 @@ rinse	wet,dip,soak,flood,clean,wash,flush
 turn	look,give,return,get,trend,come,face,change,go,corner,move,pass,sheer,twist,flip,rotate,bend,bit,gee,convert,switch,throw,run,swing,spiral,spin,wheel,coil,gesture,roll,port,departure,time,pivot,direction,transform,toss,swivel,wind,act,shift,angle,curve,shot,put,form,translate,action,screw,reversal,cut,round,become
 outfit	costume,unit,clothes,dress,apparel
 noon	day,evening,morning,afternoon,hour
-graham	
 deliberate	measured,prudent,calculated,planned,cautious,weighed,consult,thoughtful,weigh,conscious,reflect,intended,intentional,considered,studied,informed,advised,knowing,consider,careful
 diplomacy	grace,manners,consideration,negotiation,respect,talks,dialogue,sensitivity,etiquette,courtesy
 corsair	pirate,raider
@@ -1497,7 +1416,6 @@ cottages	lodges,cabins,camps
 league	group,brotherhood,congress,society,company,class,board,consortium,fellowship,chapter,collective,guild,division,majors,organization,community,institution,chamber,team,college,council,club,association,minors,conference,institute,union,fraternity
 valentine	darling,tribute,girlfriend,boyfriend,sweetheart,steady,citation,lover,bouquet,compliment,passion,companion
 synonyms	copies,counterparts
-edison	
 motorcycle	bike
 vp	executive
 gallon	gal,barrel
@@ -1526,7 +1444,6 @@ study	inspect,review,examine,investigate,course,class,survey,consider,inspection
 falls	crashes,slides,waterfall,drops,torrent,avalanche,trips,slips
 rename	designate,brand,nominate,denote,title,name,surname,nickname,specify
 continuation	preservation,persistence,endurance,duration,prosecution,survival,repeating,durability,activity,extension,continuity
-lien	
 backstreet	pass,corridor,trace,road,freeway,pike,row,boulevard,roadway,avenue,arterial,street,drive,drag,highway,way,branch,artery
 jenny	tail,jack,seat,trunk,rear,torso,bottom,donkey,mule,body,behind,posterior,stern,can,horse
 eager	pumped,ambitious,dying,ready,avid,nuts,anxious,willing,enthusiastic,hungry,greedy,keen,happy,interested,excited,great,restless
@@ -1534,11 +1451,9 @@ almighty	fierce,heavy,vicious,exquisite,profound,intense,intensive,hard,deep,vio
 proto	gene
 simulation	modelling,mock,imitation,fake,carbon,approximation,impression,image,replication,copy,print,facsimile,reproduction,replica,dummy,version,model,clone,duplication,miniature,duplicate,reconstruction,modeling
 magnetic	intriguing,engaging,charming,exciting,fascinating,appealing,interesting,attractive
-caterpillar	
 mattresses	sofas,racks,beds
 quiz	tease,inquire,test,grill,query,investigate,attacker,exam
 authentic	reliable,legitimate,very,pure,historical,honest,certified,real,actual,true,authoritative,genuine,convincing,right,credible,accurate,identifiable,original
-glasgow	
 relocation	mobility,migration,stirring,shifting,transfer,movement,transport,move,shift,motion
 localized	sectional,local,regional,component,constituent
 renewal	regeneration,repetition,iteration,replication,restoration,revival,replay,duplication,repeat,rehabilitation
@@ -1553,7 +1468,6 @@ cinnamon	laurel
 lanes	passages,passes,drives,approaches,routes,walks,rows,paths,roads,trails,pike,avenues,tracks,arteries,ways,waterways,streets,airways,highways
 remodeling	change,redesign,amendment,adjustment,transformation,revision,modification,revise,alteration,variation,shift,difference
 individually	alone,apart,respectively,separately,independently,personally
-uma	
 beauty	looks,glamour,beautiful,appearance,attraction,glory,elegance,style,ugly,charm,feature,refinement,appeal,value,aesthetics,fairness,grace,importance
 gore	stab,spike,thrust,spear,pink,punch,spit,lance,stick,slice,pierce,peck,pick
 ombudsman	court,inspector,referee,justice,authority,expert,critic
@@ -1576,7 +1490,6 @@ lent	advanced,gave,furnished,granted
 north	us,usa,america,northern,yankee
 motel	accommodations,dorm,court,lodge,rest,hostel,spa,camp,inn,resort,campground,cabin,hotel
 finland	finn,europe,ec,eu
-epa	
 forms	thing,condition,forge,build,style,acquire,mode,create,law,object,design,practice,sort,assemble,configurations,set,plan,letter,organize,variety,process,construct,shape,constitute,rule,make,arrangement,model,appear,develop,outlines,format,fashion,pattern,found,shapes,order,structure,establish,figures,application,complete,compose,manner,regulation,scheme,work,behavior,system,method,questionnaire,way,character
 personality	mortal,soul,somebody,attribute,name,superstar,trait,individual,self,celeb,notable,icon,makeup,fibre,person,fiber,charm,star,hero,vip,light,nature,figure,temper,identity,celebrity,character
 index	hand,gauge,pointer,needle,indicator,ratio
@@ -1588,9 +1501,7 @@ subclass	subgroup,group,species,sort,family,class,bracket,line,kind,type,variety
 associations	cooperative,society,company,relations,league,federation,relationships,affiliations,guild,cooperation,organization,partnership,partnerships,dealings,connections,tribe,club,interactions,unions,mergers,corporation,alliances,union,collaborations
 cups	mugs
 obsession	fetish,enthusiasm,hunger,desire,trip,problem,mania,passion
-orthopedic	
 accompany	follow,characterize,walk,bring,guide,lead,rule,protect,see,attend,company,add,companion
-chen	
 secret	mystery,unknown,code,confidence,covert,mysterious,key,unpublished,info,confidential,classified,undercover,information,restricted,underground,obscure,private
 girl	adolescent,woman,skirt,virgin,baby,teenager,kid,babe,colleen,dame,maiden,gal,miss,missy,chit,child,sister,bird,doll,maid,chick,belle
 tea	menu,feed,serving,table,board,taste,chow,gossip,buffet,drink,mess,caffeine,snack,dinner,banquet,lunch,herbal,luncheon,breakfast,supper
@@ -1661,7 +1572,6 @@ auction	trade,negotiation,purchase,sale,bargain,transaction,deal,fair
 privileged	promising,lucky,golden,favored,fortunate,honored,rich,sweetheart,blessed,happy,gifted,powerful
 workers	group,corps,department,company,lineup,staff,squad,people,slaves,faculty,crew,university,ring,organization,bunch,team,unit,force,band,clan,tribe,club,personnel,gang,side,crowd,institute,syndicate,party,troop
 congressional	parliamentary,legislature,parliament,legislative,council
-newton	
 streaming	tidal,pouring,flooding,floating,falling,effective,rolling,soaring,aerial,operating,alive,running
 obituary	notice,memorial,tribute
 greyhound	racer,hound
@@ -1691,7 +1601,6 @@ blogger	pen,person,individual,soul,writer,somebody,author,reporter,columnist,jou
 cobra	asp,racer,boa,snake,viper,serpent,python
 split	disruption,break,divorce,parcel,separation,splinter,paragraph,part,disconnect,slice,divide,division,resolve,gap,lot,canton,isolate,tear,format,open,pull,rip,separate,crack,initialize,breach,share
 vapor	blow,fog,exhibit,steam,glory,bull,pride,puff,moisture,display,crow,gas,suspension,smoke
-bruce	
 alike	so,similar,equally,like,similarly,also,likewise
 blade	sword,steel,leaf,foliage,knife
 roma	bohemian,indian
@@ -1724,7 +1633,6 @@ intersection	crossing,corner,interchange,vertex,junction
 surprising	unexpected,awesome,remarkable,unpredictable,shocking,unusual,sudden,breathtaking,amazing,extraordinary,stunning,wonderful,incredible
 composed	confident,level,smooth,relieved,cool,detached,equal,peaceful,possessed,steady,centered,together,poised,collected,relaxed,calm
 commuter	traveler,driver
-pretoria	
 preceded	anticipate
 arrange	range,pyramid,complete,position,set,schedule,organise,lay,fix,order,pile,cascade,establish,decorate,negotiate,pair,draft,heap,dress,string,distribute,array,plan,choose,organize,figure,place,prepare,marshal,decide,file,provide,settle,pose,stack,construct,promote,bundle,thread,tailor,pack,concord,manage,resolve,draw,determine,compact,put,design,chain,form,coordinate
 philosopher	promoter,interpreter,student,eclectic,champion,practitioner,apostle,supporter,dean,scholastic,scholar,libertarian,guru
@@ -1756,7 +1664,6 @@ updating	improvement,review,amendment,remodeling,alteration,modification
 cite	represent,call,order,offer,mention,illustrate,mean,remember,advert,present,tell,quote,specify,refer,raise,appeal,name,reference,repeat,indicate,instance
 installation	beginning,wiring,inaugural,establishment,investment,baptism,commencement,start,station,base,initiation,system,induction,installment,plant,installing,machinery
 ace	authority,maven,expert,proficient,wizard,maestro,single,professional,dab,unity,figure,geek,enthusiast,sharp,consultant,one,scholar,artist,digit,master,pro,specialist,hand,shark,guru
-gamma	
 states	territory,express,say,nation,speak,land,community,nations,affirm,voice,provinces,describe,countries,present,tell,specify,articulate,give,explain,lands,federation,put,union
 covenant	convention,pact,compact,alliance,contract,treaty,understanding,accord
 genetically	inherent,inherited,naturally,congenital
@@ -1778,7 +1685,6 @@ spokesperson	interpreter,spokesman,speaker,ambassador,mouth,voice,representative
 piazza	plaza,porch,square
 overcome	nose,bury,survive,stop,weather,shell,down,take,beat,best,destroy,succeed,defeat,win,get,master,trim,reduce,worst,upset,lick,conquer,dispatch,crush
 leon	mexico
-munich	
 thank	credit,acknowledge,convey,cite,salute,compliment,kiss,recognise,recognize,honor,praise
 archaeology	anthropology,excavation
 municipality	township,suburb,metropolis,town,village,ward,district,community,city
@@ -1804,7 +1710,6 @@ chats	gossip,conferences,debates,exchanges,chatter,jaws,talks
 bermuda	atlantic
 discreet	thoughtful,prudent,sensible,careful,cautious,reasonable,intelligent
 amid	between,amongst,midst,among,through,mid
-wagner	
 etiquette	mode,practice,habit,attitude,posture,rules,manner,rule,form
 sadness	despair,depression,distress,oppression,blues,rue,pain,sorrow,boredom,misery,regret,mourning,feeling,grief
 greetings	blessing,congratulations,compliment,respects,praise,regards
@@ -1879,12 +1784,10 @@ checking	examination,going,fitting,intrusion,raid,intervention,answering,survey,
 nederland	nato,holland,rotterdam,europe,netherlands,ec,eu,amsterdam
 operation	assignment,action,responsibility,service,mission,effort,activity,agency,process,requirement,business,work,detail,job,exercise,obligation,application,affair,enterprise,transaction,trip,deal,movement,procedure,use,force,office,brief,post,charge,duty
 defining	surrounding,rounding,process,tracing,lining
-bartlett	
 exceptionally	extra,damn,damned,far,too,wicked,awful,positively,remarkably,utterly,such,thoroughly,notably,most,deeply,deadly,incredibly,completely,mighty,exceeding,very,seriously,specially,especially,severely,wholly,terribly,desperately,heavily,super,entirely,highly,extremely,jolly,absolutely,badly,particularly,so
 coming	forthcoming,approaching,upcoming,imminent,subsequent,pending,future,expected,anticipated
 instruction	style,advice,information,plan,imperative,schooling,command,direction,substance,destination,teaching,content,injunction,prescription,discipline,address,guidance,order,message,lesson,requirement,decree,do,demand,ruling,markup,word,rule,preparation,directive,recipe,formula,mandate,training,charge
 toast	dry,bake,roast,cook,salute,tribute,warm,heat,grill,crisp
-almond	
 clicking	identifying,bonding,relating
 baptism	initiation,inaugural,installment,installation,investment,immersion,induction
 woke	raised,disturbed,excited
@@ -1904,13 +1807,10 @@ explanation	information,note,answer,statement,excuse,definition,justification,il
 declining	loss,falling,aging,hung,decline,lowering,declined,doomed,discount,floppy,sliding,old,reduction,retired,aged,descending,fading,hanging,contraction,decreasing
 reels	circles,wheels,curves,rolls
 discusses	explain,debates,argues,argue,consider,raises,introduces,review,examine,considers,deliberate,disputes,debate,reviews
-coronary	
 politicians	leader,senator
 sentenced	wrong,convicted,responsible,damned,liable,doomed,punished,condemned,sorry,dismissed
 mentor	guide,adviser,intellect,advisor,instruct,counsel,counselor,teacher,trainer,instructor,coach,manager,tutor,sage
-stella	
 figurine	image,portrait,copy,sculpture,painting,model,carving,figure,photograph,picture,doll,puppet
-homepage	
 announces	declares,reveals,sounds,releases,informs,introduces,promotes,reports,publishes,broadcasts,posts
 stadium	arena,circus,construction,structure,garden,stand,park,bowl,field,dome
 minutes	transactions,hansard,seconds,proceedings,moments
@@ -1929,7 +1829,6 @@ struck	walked
 appendix	conclusion,addition,postscript,documentation,sequel,ending,supplement,addendum
 availability	command,accessible,openness,opportunity,convenience,time,available,accessibility,show,unavailable
 menus	fares,food,cards,table,tables,card,cuisine
-taco	
 careful	minute,discreet,cautious,sober,conservative,thorough,thoughtful,certain,particular,safe,protective,sure,deliberate,prudent,narrow,accurate,concerned,precise,elaborate,alert,close,rigorous
 snacks	tastes,bites,nuggets,appetizers
 obscure	remote,unknown,unclear,cloud,mysterious,odd,humble,irrelevant,mystic,deep,rare,blind,confusing,complicated,uncertain,ambiguous,eclipse,dark,questionable,blur,minor,mask,veil,dim,occult,muddy,vague,cover,distant,opaque
@@ -1944,7 +1843,6 @@ checks	bills,fees,receipts,records,expenses,tabs
 neat	slick,crisp,smart,graceful,handy,trim,accurate,efficient,sleek,organized,tidy,elegant,quick,precise,stylish
 attained	obsolete,concluded,done,executed,collected,perfect,full,performed,up,complete,terminated,entire,sweeping,achieved,over,down,satisfied,captured,ended,realized,seized,accomplished,completed,finished,through
 affection	friendship,regard,respect,desire,emotion,enthusiasm,appreciation,passion,care,devotion,heart,kindness,warmth,feeling,love,loyalty,sentiment,attachment
-yale	
 stake	ownership,portion,share,percentage,purse,chance,right,prize,fee,venture,award,claim,interest,involvement,equity,risk,part
 subsidy	scholarship,payment,endowment,pension,support,annuity,grant,contribution,bonus,allowance,premium,allocation,gift,appropriation,fund,aid,entitlement,assistance
 symphony	sonata,equilibrium,unity,balance,orchestra,proportion,symmetry,harmony,coherence,concert,music,correlation
@@ -1954,7 +1852,6 @@ maine	portland,america,me,usa,bangor,brunswick,augusta,us
 was	existed,ruled,continued,survived,lived
 paintings	drawings,oils
 remember	think,recognise,recognize,reproduce,mind,get,review,learn,remind,recall,refresh,know,retrieve
-pharmacists	
 moscow	russia
 able	equal,competent,qualified,apt,suitable,prepared,capable,good,willing,ability,expert,experienced,skilled,adequate,ready,fit,proficient
 attribution	classification,indication,sorting,point,specific,affection,marker,symbol,touch,quality,attribute,feature,sign,hallmark,note,characteristic,criterion,property,fingerprint,mark,character,trait,stamp
@@ -1978,7 +1875,6 @@ acc	command
 versatile	flexible,varied,functional,gifted,accomplished,talented,able,skilled,universal
 vain	assured,trivial,consequential,confident,selfish,important,proud,petty
 recovering	sick,tough,cured,conditioned,bouncing,ill,improved,hardy,robust,better
-burton	
 std	doctorate
 utility	use,assistance,usefulness,mileage,advantage,help,avail,service,benefit
 restaurant	tavern,cafeteria,cafe,bistro,inn,grill,diner,bar,saloon,building,outlet
@@ -1991,10 +1887,7 @@ allergy	nausea,dislike,hate,hatred
 distress	suffering,rack,misery,sadness,trouble,torture,wound,hardship,difficulty,hurt,pain,discomfort,danger,sorrow
 maven	professional,wizard,superstar,enthusiast,geek,authority,specialist,star,ace,champion,shark,master,proficient,expert,scholar,guru,sensation,consultant,maestro,artist
 moisture	water,damp,sweat,rain,mist,fog,humidity,precipitation
-appleton	
-erectile	
 confirmed	fixed,valid,chronic,natural,verified,regular,accustomed,addicted,persistent,repeat,serial,used,accepted,proved,steady,born
-geometric	
 budgeting	arranging,calculating,designing,planning,commercial,subsidy,plotting,fiscal,provision,organizing,donation,grant,preparing,funding,economic,monetary,shaping,allowance
 invisible	occult,faint,obscure,infrared,concealed,discreet,covert,hidden,ultraviolet,microscopic,unseen
 gymnastics	workout,athletics,activity,exercise,training,bodybuilding,conditioning
@@ -2005,7 +1898,6 @@ fencing	approximate,connected,closest,nearest,barrier,near,fence,connecting,cont
 clarence	carriage,rig
 saw	word,motto,saying,maxim
 es	e,metal
-shelley	
 woodland	earth,wood,timberland,land,forest,timber,greenwood,ground,silva
 inbound	incoming
 systematic	regular,organized,precise,structured,neat,detailed,standardized,efficient
@@ -2042,17 +1934,14 @@ intangible	unreal,ethereal,assets,goodwill
 optimizing	promoting,maximizing,improving,enhancing,upgrading,expanding,increasing,refining,strengthening
 ship	sheet,frame,tail,stern,yacht,transfer,tack,hold,move,screw,helm,flagship,top,haul,skeleton,quarter,wreck,liner,fleet,bay,vessel,hulk,export,transmit,shift,tender,boat,dispatch,fin,log,deck,pirate
 staples	weights,meats,hearts,cores,bottoms,kernels,masses,chiefs,centers,mains,amounts,bodies,substances,roots
-liposuction	
 creamy	rich,sticky,thick,lush,colored,heavy,colorful,fluffy,soft
 contributors	angels,donors,patrons,helpers,subscribers,donor,supporters,patron
-mango	
 harvest	yield,pick,intake,accumulate,output,gather,result,collect,crop,garner,reap
 bulgaria	sofia,nato,bulgarian,europe
 interpreting	rendering,analyzing,resolving,defining,interpretation,explaining,demonstrating
 claimant	applicant,successor,representative,beneficiary
 cuts	saws,splits,slices
 jumper	gown,sack,shift,dress
-sparrow	
 populations	culture,state,society,public,people,community
 breeds	types,likes,manners,genres,kinds,strains,descriptions,feathers,stripes,sorts,classes,species,varieties
 cheaper	budget,discount,bad,competitive,affordable,discounted,inexpensive,reasonable,poor,economical,low,popular
@@ -2061,7 +1950,6 @@ novelties	variety,gadgets,notion
 classified	categorized,grouped,sorted,secret,underground,intimate,covert,closet,personal,private,inside,restricted,undercover,confidential,silent,concealed
 feared	bothered,stressed,worried,troubled
 malaysian	malay
-helicopters	
 wednesday	wed
 movies	flick,hollywood,pictures,videotape,film,show,picture,cinema,feature,screen
 dumping	marketing,destruction,disposal,merchandising,removal
@@ -2073,7 +1961,6 @@ log	wood,journal,mark,diary,chunk,register,piece,enter,chart,timber,note,record,
 recession	recess,decline,unemployment,slide,inflation,bankruptcy,collapse,depression,niche,corner
 continues	extend,renew,last,remains,stays,progress,promote,endure,remain,stay,reach,survive,sustain,lasts,restore,advance,pursue,maintain,proceed
 getting	knowing,occupation,catching,appropriation,acquisition,hearing,discovering,understanding,mastering,learning,act,contracting,occupancy,seeing,seizure,receipt,capture,pickup,reception,deed,acquiring
-dove	
 happy	cheerful,jolly,up,lucky,favorable,bright,fortunate,hopeful,merry,content,glad,unexpected,golden,happiness,blessed,thrilled,promising,delighted,convenient
 unhappy	unfortunate,sorry,depressed,happiness,upset,worried,distressed,sad,suffering,miserable,troubled,bad,disappointed,down,blue
 workout	stretch,routine,exercise,set,bodybuilding,conclude,crack,effort,resolve,rehearsal,sweat,stretching,session,decide,exercising,work,conditioning,drill,solve,yoga,test,answer,training
@@ -2085,7 +1972,6 @@ plateau	plain,table,butte,mesa,bench,elevation,terrace,highland,dome
 emphasis	spotlight,accent,intensity,stress,weight,consideration,concentration,focus,significance,value,priority,strength,importance,attention
 nights	evenings
 funding	assistance,sponsorship,encouragement,finance,cash,money,subsidy,endowment,financing,backing
-theta	
 korea	asia
 gate	hinge,lock,exit,bar,fence,port,door,portal,hatch
 nothing	dwarf,puppet,nil,inferior,lightweight,number,insect,null,nobody,zero,shrimp,zip
@@ -2100,7 +1986,6 @@ posting	announcement,mailing,notification,advertising,advertisement,brochure,bul
 parking	setting,housing,deploying,locating,camping,lodging,room,positioning,fixing,installing,settling,planting
 consumer	feeder,customer,smoker,buyer,patron,guest,client,shopper,purchaser,user
 marketing	merchandising,wholesale,dumping,banner,billboard,ad,retail,selling,syndication,advertisement,promotion,poster,sign,retailing,buying,advertising,vending,propaganda,message,commercial,release,sale,commerce,publicity,bill,resale,publication
-proton	
 cleanliness	fitness,vitality,sanitation,shape,strength,health,purity,wellness,trait,hygiene
 avenue	lane,pathway,roadway,arterial,pike,interstate,outlet,entrance,road,channel,artery,way,freeway,street,pass,highway,row,approach,boulevard,route,drive
 insightful	keen,experienced,prudent,wise,smart,sage,thoughtful,intelligent,sharp,brilliant,scholarly,quick,clever
@@ -2127,9 +2012,7 @@ surf	spray,foam,mist,head,swell,wave,breaker
 act	conduct,execute,instrument,step,pursue,enforce,scene,bit,do,performance,turn,measure,decree,show,fiat,action,operate,move,statute,deed,routine,react,enactment,resolution,amendment,seem,play,perform,develop,undertake,law,serve,behave,bill,respond,thing,attitude,signature,number,begin,appear,order,function,operation
 automotive	moving
 grazing	feeding,eating,browsing
-mitchell	
 shortlist	list
-packaged	
 engaged	absorbed,occupied,working,busy,interested,promised,involved,hooked,matched,employed,committed
 surviving	going,animated,prevailing,vital,breathing,lively,vibrant,vigorous,remaining,dynamic,existing,current,live,active
 serving	viable,dynamic,meal,breast,operating,slice,helping,wing,productive,portion,taste,oyster,functioning,producing,busy,performing,plate,round,usable,drink,piece,yielding,useful
@@ -2151,12 +2034,10 @@ sur	lebanon
 manufactures	produces,makes,forms,constructs,builds,fashions,frames,creates,crafts
 tales	fiction,fable,myth,stories,legend,novel,yarn,account,narrative,rumor
 apologize	acknowledge,excuse,justify,explain,mitigate,confess,withdraw,admit
-pager	
 postings	brochures,releases,notifications,ads,posters,adverts,announcements,reports,messages,bulletins,advertisements,notices
 tactics	strategy,system,style,way,plan,tactic,how,process,recipe,fashion,methodology,approach,method,manner,technique
 compounds	combinations,cocktails,alloys,mixes,composites,mixtures,multiply,blends
 product	yield,stock,result,outcome,produce,production,feature,output,second,cargo,merchandise,generic,profit,amount,outlet,labor,shipment,device,brand,work,good,commodity,irregular,release,payload,fruit,ware,refill,freight,load,crop,thing,inventory,number,line,loading
-tonight	
 firing	blast,fiery,joy,battery,onset,cover,thunder,attack,shot,shooting,artillery,discharge,volatile,outbreak,burst
 corruption	evil,corrupt,crime,exploitation,decomposition,breakdown,degradation,decay,fraud,rot,infection
 mediation	reconciliation,consensus,intervention,agreement,arbitration,bargain,settlement,treaty,understanding,negotiation,arrangement
@@ -2244,7 +2125,6 @@ motivational	annoying,explosive,inspirational,inspiring
 automobile	roof,wagon,taxi,horn,auto,compact,coupe,fin,motor,suv,ambulance,truck,sedan,low,cruiser,buffer,racer,fender,reverse,high,window,third,limo,wheels,wing,coach,convertible,hatchback,heap,grille,machine,bus,trunk,gas,hood,accelerator,transportation,saloon,jeep,hack,electric,throttle,cab,bumper,car,van,first,limousine,gun
 promised	guaranteed,agreed,engaged,committed
 rugs	wigs
-dp	
 cage	crate,pen,jail,kennel,fence,coop,enclosure,aquarium,pound
 film	credit,episode,shoot,subtitle,feature,movie,sequence,flick,musical,documentary,product,footage,picture,credits,photograph,show,scene,production,shot,pic,cinema,caption
 protector	defender,tribune,protection,fighter,keeper,savior,champion,guard,hero,reminder,guardian,watchdog,patron,monitor,partisan,firefighter,custodian
@@ -2254,7 +2134,6 @@ personal	distinctive,intimate,own,personalized,personalised,patented,secret,uniq
 chin	rap,chat,chatter,converse,gossip,gas,talk,jaw,jabber,face,feature,discuss,visit
 bald	displayed,naked,uncovered,open,stripped,bare,exposed,blunt
 cairo	egypt
-sociology	
 inches	altitude,height,elevation
 hostels	campgrounds,hotels,inns,lodges,motels
 hiding	secretion,covering,screening,burial,caching,cover,stealth,stealing,mask
@@ -2264,7 +2143,6 @@ execute	implement,enforce,apply,complete,kill,administer,perform,meet,do,murder,
 rescue	deliver,salvage,delivery,recovery,free,keep,protect,preserve,redemption,recover,relief,retrieve,release,protection,salvation,save
 blades	swords
 owners	partner,holders,holder
-sings	
 allocate	lot,give,appropriate,distribute,allow,present,designate,award,divide,portion,assign
 appropriate	happy,pertinent,good,adequate,pretty,secure,convenient,becoming,apt,acceptable,pat,fitted,proper,meet,needed,balanced,fitting,relevant,useful,true,suitable,borrow,correct,applicable,required,fit,right
 diffuse	mantle,spread,creep,bleed,windy,run,redundant
@@ -2279,7 +2157,6 @@ fell	slam,slap,tumble,punch,hit,level,log,floor,bang,down,slash,drop,cut,shoot,f
 strengthen	reinforce,secure,temper,support,steady,alter,extend,brace,modify,change,enlarge,enhance,sustain,increase,restore,establish,confirm,consolidate
 bottom	tail,seat,floor,heel,bed,face,basement,side,ground,sole,heart,rear
 node	bump,stem,swelling,lump,growth,knot,tumor
-ching	
 relief	support,maintenance,sympathy,comfort,help,satisfaction,happiness,encouragement,cheer,assistance
 gran	nan,granny,grandmother,grandma
 whales	monsters,giants,titans,dinosaurs,elephants,elephant
@@ -2291,7 +2168,6 @@ abortion	conclusion,ending,repeal,termination,cancellation,calling,revocation
 overwhelming	spreading,infectious,devastating,vast,tangible,epidemic,stunning,amazing,catching
 camping	lodging,roofing,housing,boarding
 mind	opinion,attitude,mood,thought,view,spirit,attention,judgment,imagination,determination,insight,knowledge,skull,brain,desire,nous,eye,intelligence,will,sense,perception,consciousness,thinking,head,perceive,wisdom,genius,feeling,instinct,unconscious,dislike,cognition,ego,talent,wish,soul,notice,sentiment,intellect
-lancaster	
 crust	skin,layer,sauce,cheek,nerve,face,confidence,surface,plate,brass,assurance
 popularity	acclaim,vogue,quality,popular,acceptance,enthusiasm,reputation,demand,style,following,fame,trend,favor
 needle	tweak,prod,badger,bait,hector
@@ -2331,14 +2207,11 @@ pakistani	pakistan,asian
 rad	neat,nifty,groovy,superb,fabulous,wonderful,excellent,terrific,awesome,breathtaking,incredible,acceptable,unbelievable,fantastic,great,satisfying,positive,marvelous,satisfactory,remarkable,spectacular,favorable,valuable,outrageous,exceptional
 occur	give,repeat,hit,appear,break,pass,exist,arise,go,come,reveal,intervene,proceed,chance,show,follow,strike,result,operate,do,anticipate,shine,develop,be,fall,happen
 disks	fragments,parts,bits,chips,portions,sections,scraps,sheets,particles
-malaria	
 buff	enthusiast,lover,followers,fool,fan,nut,supporter,collector,friend,hound,addict,maven,freak,expert,bug,following
-lotus	
 dominant	premier,central,key,primary,master,greatest,major,principal,superior,big,capital,cardinal,leading,status,prevailing,influential,chief,effective,top,great,paramount,powerful,prevalent,highest,supreme,outstanding,prior,prominent,governing,controlling,foremost,commanding,position,sovereign,first,main
 poll	opinion,count,block,enquiry,bean,inquiry,vote,skull,examine,voting,head,tally,dome,survey,nut,ballot,register,crown,interview,research,enroll
 cinderella	woman
 declines	refuses,avoids,disputes,denies,rejects,passes
-calvin	
 winds	blows,currents,drafts
 psychologist	physician,scientist,doctor,therapist,analyst,adviser
 banking	grouping,collecting,gathering
@@ -2349,12 +2222,8 @@ frank	sincere,candid,vocal,straightforward,open,straight,earnest,plain,forthcomi
 string	wire,rope,cable,strand,chain,lace,cord,sequence,row,line
 bikini	swimsuit,bra,shorts,lingerie
 cpi	assessment,cost,value
-wheeler	
-mayer	
 mortality	grave,killing,dead,murder,sleep,death,homicide
-ba	
 steal	cabbage,pinch,remove,nip,strip,keep,take,cop,pocket,lift,nick,seize,grab,rob,sack,appropriate,bag,hustle,sneak,pick,roll,abstract,boost,hook,pirate
-welch	
 stood	was,place,locate,stay,last,stop,pause,put,remain,lay,remained,set,bore,settle,rise,continue,rest,hold,rank,erect,sat
 clearance	leave,approval,allowance,permit,accreditation,interval,sanction,warrant,licence,granting,signature,consent,certification,license,authorization,permission,seal
 reverse	undo,right,lift,repeal,interchange,alter,correct,exchange,switch,modify,change,commute,return,shift,flip,turn,alternate,tack
@@ -2363,7 +2232,6 @@ lagoon	pool,gulf,roads,harbor,narrow,canal,haven,bay,loch,lake,dock,cove,pond,so
 period	hour,epoch,downtime,millennium,blossom,morning,watch,date,prime,era,years,day,yr,reign,sleep,year,time,hitch,drought,lease,eve,youth,flower,evening,nap,night,century,week,tide,past,occupation,stage,dark,dawn,month,term,season,bout,daytime,daylight,lifetime,uptime,span,flush,run,festival,bloom,hours,decade,prohibition,stretch,semester,tour,duration,overtime,phase,quarter,peak,age,window,school,times,honeymoon,generation,life,course,weekend,cycle
 sketch	account,blueprint,silhouette,image,drawing,outline,picture,chart,study,contour,version,representation,paint,chalk,design,copy,piece,illustration,summary,draft,cartoon,description,painting,portrait
 numbered	calculated,told,counted,checked,computed
-braille	
 resumes	continues
 resist	refuse,fight,prevent,confront,escape,endure,abide,continue,oppose,combat,curb,maintain,withstand
 colorful	lively,deep,various,motley,shot,fluorescent,vivid,striped,distinctive,unusual,dotted,bright,brilliant,colored,rich,color,vibrant,colour,varied,rainbow
@@ -2382,7 +2250,6 @@ lack	require,deficiency,loss,demand,want,need,deficit,reduction,poverty,absence,
 world	province,folks,business,class,academia,nature,realm,field,people,race,community,group,species,domain,public,humanity,society,area,system,life,everyone,earth
 port	roads,channel,harbour,harbor,wharf,anchorage,dock,marina,haven,lagoon,bay,cove
 sweet	pleasing,smooth,delicious,aromatic,gentle,chocolate,pleasant,delightful,beloved,candy,darling,clean,spicy,tender,appealing,dessert,special,soft,snack,loving,favored,generous,loved,beautiful,engaging,fresh,dear,charming,precious,rich,soothing,fond,pure,mild,pet,favorite
-churchill	
 rig	coupe,buggy,furnish,equip,manipulate,carriage,fix,gig,tandem,cab
 analyse	name,trace,assay,view,study,canvas,divide,compare,examine,follow,survey,screen,consider,audit,inspect,cut,assess,check,diagnose,evaluate,review,investigate
 fibre	spindle,tolerance,courage,strand,endurance,resolution,nerve,beard,fiber,string,backbone,brass,determination,guts,material
@@ -2414,7 +2281,6 @@ volume	quantity,pile,bundle,amount,mountain,bunch,lot,dozen,much,content,chunk,s
 toon	cartoon
 tons	pots,volumes,stacks,hundreds,dozen,lots,much,quantities,yards,barrels,loads,piles,deals,bundles,sights,packs,stores,scores,hundred,dozens,mountains,masses
 bless	raise,stir,celebrate,oil,thank
-pei	
 conscience	mind,ethics,values,standards,character,gut,principles,heart,morality,blood,soul
 mesothelioma	cancer,mesothelioma
 anyways	however,regardless,whatever,anyway,nevertheless
@@ -2423,7 +2289,6 @@ consultations	talks,counsel,seminars,discussions,meetings,conversations,debates,
 suv	coach,automobile,wheels,mini,intermediate,wagon,bus,van,auto,sedan,car,convertible,motor,hatchback,compact,machine,coupe,woody,limousine
 man	male,adult,stiff,bachelor,joe,sir,person,boy,hunk,guy,samson,buster,fellow,gentleman,dude,lad,ex,swell,boyfriend,bull,cat,stud,chap,esq
 stockholm	sweden
-melissa	
 mods	adolescent,mods,teen
 comparison	ratio,association,relationship,correlation,relation,similarity,equation,testing,connection,contrast,equivalence,example,linkage,observation,analogy,confrontation,identification,comparing,examination,affinity,parity,par
 breeding	origin,lineage,extraction,family,birth,development,training,strain,genealogy,blood,stock,line,ancestry,descent,pedigree
@@ -2515,17 +2380,13 @@ refill	refresh,fill,budget,reservoir,fund,replacement,mixture,layer,stock,reserv
 uptime	period
 fragile	weak,fine,delicate,soft
 refuses	rejects,denies,declines
-mast	
-li	
 thousand	thou,grand,k,yard,g
 seldom	rarely,occasionally,hardly,never,sometimes
 idea	design,conclusion,conception,observation,program,sense,ideal,burden,impression,motif,inspiration,reaction,keynote,view,opinion,concept,meaning,scheme,objective,thought,notion,plan,theme,substance,content,feeling,interpretation,image,reflection,intention,understanding,form,solution,belief,theorem,theory,construct,perception,picture,abstraction,suggestion,programme
 ball	egg,softball,basketball,football,globe,ring,chunk,bead,volleyball,bowl,marble,sphere,orb,circle,baseball,loop,jack
-klein	
 labeling	stamping,tagging,marking,identifying,branding
 scenic	grand,panoramic,dramatic,breathtaking,spectacular
 arcade	hall,arch,piazza,construction,mall,corridor,gallery
-sander	
 shape	forge,order,format,straight,define,produce,fashion,trim,pattern,modify,keeping,repair,contour,shadow,prepare,guide,regulate,build,adapt,body,silhouette,condition,become,frame,architecture,aspect,configuration,form,mold,curve,outline,model,construct,develop,estate,tailor,health
 buildings	land,goods,towers,plot,tract,ownership,structures,cabins,wealth,home,farm,sheds,property,equity,worth,house,houses,cottages,estate
 wages	payment,reward,consequence,salary,pay,earnings
@@ -2536,7 +2397,6 @@ gesture	indication,motion,movement,thrust,posture,expression,reminder,signal,sig
 painting	canvas,portrait,design,panorama,icon,sketch,miniature,drawing,composition,landscape,picture,art,watercolor,abstraction,oil,illumination
 position	environment,site,arrange,viewpoint,appointment,lead,slot,employment,anomaly,wing,lie,stance,view,office,opinion,reputation,state,vantage,right,role,job,function,locate,situation,landmark,spot,place,area,standing,profession,arrangement,capacity,station,polls,front,back,status,condition,stick,left,employ,seat,location,stand,rank,rear,connection,put,career,post,point,attitude,pitch,setting,duty
 directing	guiding,unlimited,governmental,directive,organization,rule,first,legislation,potent,presiding,principal,running,supervisory,departmental,legislative,lead,commanding,controlling,leading,sovereign,regulatory,autonomous,maintenance,ruling,authority,policy,directional,paramount,head,managerial,major,prevailing,management,managing,main,ministerial,performing,control,dominant,prevalent,absolute,senior,protection,agency,government,care,supervision,administrative,organizational
-menopause	
 tubing	drain,pipe,sock,conduit,tube,column,piping,stem,straw,tights,coil,barrel,hose
 arranged	fixed,tidy,certain,precise,stated,stuffed,periodic,apt,defined,settled,recommended,efficient,adapted,accessible,thoughtful,neat,coordinated,situated,constant,restricted,established,definite,ripe,conscious,aware,organized,expected,steady,controlled,prospective,located,planned,loaded,qualified,processed,regulated,wrapped,willing,systematic,scientific,standardized,thorough,formal,deliberate,managed,supervised,planted,placed,able,definitive,ordered,inclined,limited,resolved,laid,handy,scheduled,agreed,crowded,continuous,even,routine,suggested,monitored,filled
 namely	especially,specially,specifically,particularly
@@ -2548,7 +2408,6 @@ cover	ice,wrap,wax,tent,spell,overlay,surround,face,grease,involve,jacket,blanke
 addressed	talk,call,send,forward,managed,discuss,hacked,try,handled,give,treated,manipulated,negotiated,played,took
 outer	outlying,external,satellite,exterior,outside,outward,position
 nevertheless	nonetheless,yet,though,notwithstanding,however,still
-warwick	
 composers	musicians
 divorce	split,disconnect,separation,partition,separate,cleavage,dissolution,division,dispute,breach
 king	sovereign,baron,monarch,prince,lion,emperor,napoleon,tycoon,star,captain,royalty,lord,rex
@@ -2557,7 +2416,6 @@ appreciation	gratitude,respect,improvement,love,regard,knowledge,sympathy,enthus
 administrator	leader,dean,inspector,custodian,judge,manager,official,officer,exec,president,director,controller,organizer,authority,chief,commissioner,commander,head,superintendent,supervisor,minister,executive
 writers	columnist,reporter,pens,journalist,editor,poet,correspondent,poets,author,authors,columnists,critic,bloggers
 shallow	restricted,smooth,empty,surface,trivial,depth,flat,limited,measurable,horizontal,hollow,foolish,flush,superficial,finite
-rowan	
 segment	slice,whole,member,straight,subdivision,length,bend,subsection,sector,unit,component,piece,section,part,curve,partition,portion,leaf,division
 listprice	valuation,rate,fee,cost,worth,price,value
 swing	pitch,license,rhythm,flap,hang,slack,licence,curve,stroke,rotate,pivot,space,turn,swivel,wave
@@ -2565,7 +2423,6 @@ math	science,computation,analytical,maths,mathematics,algebra,figures,calculatio
 basque	france,european,spain
 happens	hit,chances,does,is,meet,comes,arrive,fall,result,pass,occurs,passes,develop,cooks,appear,arise,proceeds
 glove	land,capture,catch,clutch,grip,trap,bay,collar,hook,rope,seize,grasp,arrest,rap,bag,net,mesh,secure,nail,corner,grab,fist,get,cop
-meanwhile	
 created	invoked,fictional,caused,induced,promoted,imagined,arising,bogus,made,false,prompted,produced,worked,misleading,did,imaginary,simulated,generated,assumed,fabricated,legendary,unreal,brought,starting,introduced,effected,fabulous,wrought,bred,beginning,yielded
 offense	violation,insult,debt,slight,assault,felony,behavior,conduct,sin,error,crime,attack,injury,behaviour,breach
 tibetan	tongue
@@ -2578,7 +2435,6 @@ january	noel,jan,christmas
 feel	get,mood,suggest,beam,shine,receive,impression,burn,atmosphere,aura,think,die,acknowledge,appear,joy,nurse,see,understand,assume,try,hold,regret,harbour,rue,sense,welcome,entertain,realize,suffer,experience,consider,have,notice,appreciate,endure,seem,meet,enjoy,know,feeling,harbor,hear,pride,smell,perceive,expect,quality,touch,taste,glow,anger
 hickory	strap,whip,cane,billy,switch,business,birch,staff,crop
 promotes	advocate,benefit,stimulate,improves,sell,boost,encourage,push,raise,upgrades,increase,sponsor,support,cooperate,endorse,raises,speed,develop,favor,advertise,urge,upgrade,advances,advance,further,improve
-lynx	
 pilots	flyers
 bombs	misses,disasters,failures,losers
 manifold	multiple,myriad,various,piping,diverse,divers,varied
@@ -2606,7 +2462,6 @@ exile	dispersion,displacement,migration,outlaw,refugee
 pledge	assure,engage,promise,oath,assurance,covenant,agreement,guarantee,mortgage,word,commit
 attendance	attention,help,assist,appearing,facilitation,care,turnout,lift,backing,encouragement,boost,aid,promotion,service,support,participation,presence,attending,advancement,appearance,sponsorship,assistance
 hatchback	convertible,car,pickup,machine,woody,wheels,mini,motor,ride,coupe,taxi,auto,automobile,wagon,sedan,truck,suv,coach,transportation,bus,limousine,jeep,van,intermediate,compact
-solicitors	
 picks	selections,choices,candidates,nominees,bets,chosen,nominations,options,favorites
 additives	adapters,appliances,supplements,supplement,adaptors,attachments,accessories,options,subsidiaries
 locating	determining,localization,determination,location,getting,learning,detecting,discovering,finding
@@ -2619,7 +2474,6 @@ imaginative	inspired,innovative,visionary,fantastic,creative,talented,romantic,v
 declaration	assertion,announcement,confession,claim,statement,profession,threat,manifesto,argument
 theorem	assumption,theory,premise,thesis,proposition,hypothesis
 diabetes	dm
-allen	
 craftsman	professional,artist,technician,master,maker,artisan
 detailed	specific,exact,elaborate,thorough,definite,complicated,precise,graphic,minute,complete,exhaustive,comprehensive,full,entire,particular,accurate,descriptive,graphical,vivid
 gel	set,strengthen,cake,membrane,reinforce,swell,freeze,concrete,arise,jelly
@@ -2627,7 +2481,6 @@ armies	corps,company,battalion,squad,troops,soldiers,unit,hosts,infantry,command
 splits	parts,pulls,separates,isolates
 indigenous	intrinsic,constitutional,aboriginal,natural,fundamental,essential,local,native,congenital,inherited,inherent,domestic,original
 grown	fertile,mature,green,lush,adult,big,dense,rich,productive
-eighth	
 unsupported	absurd,questionable,unclear,inconsistent,uncertain,unreasonable,unnecessary,false,weak,invalid,misleading
 pitch	sky,descent,dip,point,angle,flip,drop,dive,plunge,toss,submarine,slip,tumble,immersion
 bulletin	newspaper,mag,serial,announcement,zine,yearbook,periodical,book,flash,edition,rag,gazette,story,report,review,dispatch,publication,organ,notice,magazine,paper,journal,newsletter
@@ -2656,7 +2509,6 @@ option	opportunity,adjunct,adapter,call,derivative,attachment,choice,enhancement
 aged	elderly,ageing,older,ancient,senior,old,aging
 meaningless	pointless,silly,empty,stupid,absurd,insane,trivial,slight,nonsense,useless,unreasonable,mindless,hollow,foolish,negligible,minor,little,vague
 participation	intervention,engagement,involvement,concern,purpose,cooperation,help,part,support,attendance,presence,role,commitment,work,contribution,aid,assistance,sharing
-dictionaries	
 inquiry	study,scrutiny,questionnaire,probation,request,investigation,probe,experiment,experimentation,exploration,enquiry,question,inspection,research,search,query,probing,examination,hearing,audit,questioning,survey,analysis
 vista	perspective,view,scene,outlook,coast,glimpse,landscape,background,panorama,ground,prospect,exposure,aspect,scenery
 drinking	consumption,intake,expenditure,consuming,sucking,licking,uptake,utilization
@@ -2677,7 +2529,6 @@ exploits	works,abuse,utilize,adventure,mine,abuses,accomplishment,handle,deed,ch
 imagined	imaginary,visionary,fictional,fantastic,ideal,unlikely,invented,theoretical,legendary,pretend,unreal,phantom
 twice	double
 smaller	junior,subordinate,less,lesser,lower,small,minor
-arabic	
 funk	depression
 vending	buying,demand,removal,selling,merchandising,reduction,trade,sale,destruction,distributing,business,transaction,auction,deal,clearance,marketing,dumping,transfer,trading,purchase,retailing,disposition,demolition
 colorado	denver,republican,arkansas,boulder,usa,sherman,pueblo,co,us,america
@@ -2686,14 +2537,12 @@ analysts	columnists,reviewers,critics,observers
 chatter	conference,talking,talk,jaw,discourse,dialogue,chat,debate,gossip,rap,dialog
 cruel	vicious,malicious,evil,fell,bitter,brutal,wicked,savage,harsh,painful
 unconscious	asleep,latent,cold,lost,innocent,unaware,collapsed,suppressed,out
-louis	
 owning	having,commanding,enjoying,keeping,retaining,holding
 martial	aggressive,military
 titanic	bumper,cosmic,huge,mighty,super,mammoth,monster,large,vast,oversized,gigantic,majestic,oceanic,giant,galactic,big,astronomical,jumbo,immense,planetary,enormous,heroic,mega,considerable,great,tremendous,substantial,grand,massive
 admit	sign,enter,reveal,receive,declare,introduce,agree,allow,accept,take,approve,indicate,tell,acknowledge,permit,confirm,grant,announce,hold,say,disclose,sustain,recognize,affirm,confess,talk
 wilderness	frontier,open,outdoors,outback,forest,desert,country,jungle,nature,bush,wild
 other	otherwise,distant,unlike,another,distinct,new,several,various,different,diverse,separate,opposite,more,alternative,varied,distinctive
-aloe	
 muscles	drives,presses,forces,makes,cows,pressures
 adverse	conflicting,damaging,destructive,harmful,threatening,unfortunate,hostile,negative,bad,dangerous,risky,hazardous,counter
 reunion	meeting,workshop,conversation,discussion,rally,homecoming,convention,demonstration,gathering,reconciliation,clinic,assembly,union
@@ -2702,7 +2551,6 @@ degradation	descent,eclipse,subversion,destruction,decrease,humiliation,impairme
 yards	courts,enclosures
 happen	result,shine,repeat,occur,proceed,hit,give,intervene,operate,anticipate,arrive,break,do,appear,arise,strike,cook,fall,be,develop,pass,meet,go,chance,come
 smith	wizard,pro,scholar,maestro,maven,mechanic,wright,geek,shark,sharp,consultant,authority,professional,artist,technician,advisor,ace,adviser,proficient,hand,master,specialist,guru,expert,operator
-shilling	
 dale	vale,canyon,gorge,glen,hollow,valley
 toolbox	chest
 presents	now,today,suggest,stage,declare,offers,give,do,show,raise,carries,display,stages,offer,pose,gives,shows,award,submit,performs,cite,produce,perform
@@ -2725,7 +2573,6 @@ bling	rock,jewels,accessory,jewelry,ice,fancy,decoration,jewel
 speak	read,communicate,troll,rant,bark,shout,state,declare,jabber,express,whisper,give,publish,jaw,rave,put,snap,tell,share,bay,begin,argue,announce,convey,present,discuss,say,swallow,utter,articulate,chatter,pass,deliver,go,tone,voice,chat,mouth,sing,talk
 clan	guild,circle,club,squad,lot,network,fraternity,elite,relation,league,sect,family,kin,bunch,fold,body,society,faction,folks,pack,gang,mob,set,crowd,genealogy,organization,relative,ring,community,band,tribe
 route	interstate,roadway,round,arterial,line,passage,orbit,lane,pike,course,itinerary,beat,circuit,row,artery,direction,freeway,path,trail,street,track,drive,pass,boulevard,way,journey,avenue,road,highway,pattern
-basil	
 registry	directory,schedule,catalog,roster,calendar,catalogue,note,yearbook,record,scrapbook,table,agenda,listing,itinerary,file,evidence,testimony,story,report,lineup,list,index,history,transcript,program,chart,document,register,timetable,roll,collection,journal,menu,checklist
 mails	matters,messages,shipments,packages,letters,postcards,cards,posts
 biotech	biotechnology
@@ -2733,10 +2580,8 @@ stretching	production,expanding,improvement,extension,deep,continued,delay,lengt
 pyramid	hill,benefit,bank,stack,drift,bar,pile,bed,rick,shrine,gain,accumulation,aggregate,barrow,mountain,grouping,layer,memorial,tomb,collection
 languages	speeches
 particles	rays,ounces,shades,hints,shadows,traces,molecules,bites,bits,touches,fragments,smells,little,sparks,spots,atoms,parts,strains,drops,peanuts,grains
-cpr	
 humorous	killing,pleasing,entertaining,screaming,comic,pleasant,dry,playful,amusing,ironic,ridiculous,witty,funny,hilarious
 mornings	days
-ether	
 ah	well,indeed,hey,cry,hello,insertion,shout,ha,gee,what,why,no,oh
 raider	spoiler,attacker,pirate
 tribunal	judge,judiciary,jury,justice,bench,court,board,assembly,forum,committee
@@ -2764,10 +2609,8 @@ bypass	avoid,omit,ignore,escape,neglect,skirt
 precisely	exactly,specifically,due,absolutely,accurately,sharp,full,correctly,strictly,right,literally,just
 eliminating	excluding,banning,erase,defeat,exclude,waive,cancel,ignore,preventing
 inventory	listing,fund,stock,reserve,pool,list,supply,index,budget,repertoire,resource,reservoir
-blacks	
 homeland	country,home,state,land
 greeted	addressed
-eritrea	
 considerations	attention,study,scrutiny,respect,discussion,judgment,factor,reflections,plan,difficulty,debates,thoughts,problem,accounts,awareness,evidence,concern,review,proposal,issue,idea,studies,examination,development,debate,application
 mega	bumper,cosmic,huge,mighty,super,mammoth,monster,vast,oversized,gigantic,oceanic,giant,galactic,big,astronomical,jumbo,magnificent,immense,planetary,enormous,commanding,heroic,major,imperial,noble,considerable,great,good,tremendous,substantial,striking,grand,massive,titanic
 creep	nuisance,glide,cad,inch,sneak,pill,savage,nerd,hound,jerk,snake,idiot,rat,clown,beast,fool,cur,dog,travel,go,move,heel
@@ -2775,8 +2618,6 @@ rewritten	modified,corrected,fixed,amended,improved,updated,reformed,adjusted,al
 temples	churches
 works	yields,occasions,effects,brings,mill,complex,causes,factory,brewery,plant,still,creates,generates,produces,does,mint,prompts,encourages,breeds,makes
 hill	slope,ridge,dune,highland,tor,elevation,bank,stack,mound,hillside,heap,cliff,bluff,mountain,pile
-navajo	
-registrations	
 tears	split,wounds,chase,separate,pull,wrench,crack,hole,injuries,break,slash,damage,shoot,rents,scratches,activity,fractures,divide,crying,grab,rush
 relating	hint,study,analogy,applicable,clicking,note,use,contrast,relevant,relation,alike,related,identification,apt,similarity,correlation,ratio,discipline,observation,experience,drill,action,operation,preparation,quotation,testing,comparable,pertinent,identifying,connection,bonding,mention,example,training
 bachelor	maid,maiden,man,ex
@@ -2784,7 +2625,6 @@ bathroom	convenience,tub,toilet,throne,can,dwelling,stool,pot,room,home,bath
 so	well,apparently,too,indeed,quite,very,accordingly,extremely,thus,therefore,then,hence,remarkably,unusually,consequently
 overture	suggestion,inception,proposal,invitation,bid,presentation,signal,proposition,origin,prelude,preliminary
 sightseeing	sailing,navigation,ride,trek,tour,movement,looking,driving,flying,look,excursion,trip,transit
-dentist	
 connected	similar,matching,like,parallel,analogous,joined,alike,affiliated,associated,attached,related,corresponding,akin,same,united,such,comparable,correspondent,allied,linked
 complement	supplement,integrate,achieve,construction,addition
 put	sign,throw,rest,arrange,step,stand,suggest,jar,insert,lean,settle,introduce,pile,place,bring,give,middle,bed,seat,dispose,install,barrel,slap,stick,park,seed,turn,require,marshal,plant,load,focus,locate,offer,present,pose,recess,lose,space,force,replace,invest,make,thrust,set,position,pillow,submit,coffin,fix,impose,bottle,establish,deposit,docket,bucket,sit,tee,misplace,ship,ground,move,lay,trench
@@ -2795,7 +2635,6 @@ clerical	religious,missionary,pastoral,episcopal,ministerial,evangelical
 magenta	wine,plum,crimson,glowing,lilac,lavender,flaming,cardinal,maroon,color,violet,coral,rose
 ukraine	kiev,europe,odessa,cis
 ri	brown,providence,usa,newport,us,america
-christopher	
 times	seconds,minutes,occasions,cycle,generation,term,day,stage,moments,age,period,time
 fix	lock,amend,correct,dilemma,revise,shift,resolve,settle,place,regulate,dispose,buy,fill,overhaul,install,piece,put,park,better,stick,patch,lay,prepare,specify,plant,adjust,define,restore,locate,mess,darn,doctor,repair,sole,set,position,reach,deposit,establish,secure,solve,limit,fiddle,move,improve,get,rebuild,heel
 followers	soldiers,disciples,everyone,group,nation,students,apostles,supporters,fan,country,society,people,lover,pupils,following,party,scholars,multitude,class,mass,masses,community,population,audience,missionaries,buff
@@ -2815,8 +2654,6 @@ feature	identify,accent,badge,factor,property,attraction,character,component,ele
 path	route,trajectory,procedure,steps,roadway,line,pathway,passage,lane,aisle,course,rail,direction,trail,street,track,way,avenue,road,highway
 derivative	partial,computation,secondary,differential
 approximation	image,credit,estimate,imitation,impression,miniature,reconstruction,reserve,print,guess,version,simulation,estimation,extra,imprint,guessing,computation,calculation,idea,shot,spare
-chad	
-snakes	
 lithuania	lithuanian
 farmhouse	ranch,manor,plantation,orchard,garden,spread,farm,homestead
 sibling	relative,relation,brother,sister,blood,cousin,quad,family,twin
@@ -2860,7 +2697,6 @@ stranger	unknown,guest,alien,visitor,immigrant
 station	position,base,terminal,facility,quarter,service,business,location,install,assign,establish,site,house,post,job,depot,installation,operation
 jays	bucks
 biting	piercing,bitter,cutting,sharp,keen,raw,harsh
-dong	
 reportedly	likely,externally,presumably,probably,supposedly,apparently,perhaps,possibly,seemingly,allegedly,evidently
 niger	africa
 stimulating	electric,moving,challenging,appealing,absorbing,exciting,fascinating,inspiring,interesting,lively,breathtaking,stirring,intriguing
@@ -2888,7 +2724,6 @@ riviera	italia,france,italy
 proposition	suggestion,lemma,impression,theory,proposal,invitation,statement,recommendation,converse,term,particular,hypothesis,inference,thesis,guess,assumption,theorem,motion,premise,universal
 saves	delivers
 stills	arrests,checks,stops,catches,holds,blocks,stalls,stays
-ferdinand	
 pants	drawers,shorts,trousers,jeans
 mermaid	gnome,imp
 wing	circle,bat,coalition,insect,ala,body,block,arm,group,faction,organ,angel,side,bloc,bird,party,branch,movement,sect,team,unit,set
@@ -2923,7 +2758,6 @@ clinics	hospitals
 possibilities	prospects,potentials,probabilities,capabilities
 crashes	collisions,accidents
 better	beat,exclusive,exquisite,special,outstanding,superb,stellar,exceptional,elite,terrific,advance,amended,prime,premium,exceed,preferable,raise,superior,splendid,excel,enhance,greater,select,wonderful,excellent,fabulous,elegant,rare,improving,recommended,well,fancy,great,correct,marvelous,choice,improved
-runners	
 aides	helpers,deputy,servants,pluto,assistant,aids,supporter,assistants
 vendors	sellers,retailers,merchant,distributors,dealer,dealers,traders,brokers,merchants
 raging	acute,extreme,biting,furious,exquisite,violent,intense,fierce
@@ -2931,7 +2765,6 @@ exporting	selling,marketing,retailing,good,distributing,export,handling,vending,
 enters	accesses
 touchdown	light,goal,score,settle,land
 dime	cheap,peanuts,hay,song
-ukrainian	
 il	cardinal
 corrected	revised,reversible,fixed,amended,repaired
 marriages	engagements,commitments,matches,relationships
@@ -2945,7 +2778,6 @@ scripture	faith,word,law,bible,testament,truth,matter,text,case,evidence,book,ex
 senator	congressman,politician
 attorneys	agents,reps,ministers,managers,representatives,delegates,factors
 blueprint	photograph,recipe,plan,program,picture,scheme,way,project,design,pic,model,arrangement,system,draft,exposure,prototype,sketch,proposal,idea,strategy,game
-gaelic	
 cries	chatter,shout,whistle,sigh,cheer,complain,scream,bark
 portraits	definitions,tales,descriptions,pictures,accounts,sketches
 bud	juvenile,squirt,flower,cub,youth,monkey,teenager,baby,bloom,teen,chap,child,adolescent,kid,chick
@@ -2969,7 +2801,6 @@ wonders	awe,phenomena,think,stare,fear,curiosity,shock,surprise,confusion,marvel
 ape	play,repeat,mime,mock,copy,parody,echo
 want	ambition,require,hope,demand,miss,need,like,wish,hunger,seek,envy,prefer,desire,long,love,lust,fancy,care,enjoy,choose
 transplant	bear,lug,modify,carry,move,alter,transfer,tote,drive,haul,convey,cart,remove,transmit,transport,replace,shift,relocate
-blair	
 specially	especially,expressly,particularly,specifically,uniquely,notably
 flint	silica
 via	across,through,by,along,near
@@ -2988,8 +2819,6 @@ provost	manager,director,chief,executive,head
 expanded	extended,considerable,large,comprehensive,endless,ample,blown,higher,tremendous,immense,spacious,enduring,other,extra,further,pervasive,massive,excess,deep,vast,full,enormous,lengthy,loose,huge,broad,major,infinite,susceptible,gigantic,high,sustained,also,big,mammoth,sweeping,continued,new,extensive,unlimited,great,tall,clear,free,accessible,wide
 concentrate	reduce,accumulate,establish,integrate,apply,put,consolidate,focus,cluster,refine,extract,turn,remove,settle,combine,strengthen,eliminate
 instrument	analyzer,engine,weapon,extractor,vehicle,appliance,arm,medium,certification,apparatus,certificate,device,organ,whip,machine,machinery,gear,equipment,document,material,mechanism,gadget
-brit	
-methyl	
 reg	requirement,guideline,ruling,rule,instruction,constitution,act,decision,charge,mandate,value,ordinance,decree,procedure,standard,principle,charter,case,order,law,legislation,regulation,statute,measure,precedent,code
 nitrogen	air,element,n
 idiot	jerk,stupid,turkey,simple,natural,dip,loser,clown,fool,dummy,goose,donkey,yahoo
@@ -3009,10 +2838,8 @@ iron	strength,persistence,steel,freedom,metal,rigid,backbone,power,sand,fe
 preserved	released,intact,secure,covered,rescued,pristine,sweet,protected,freed,retained,mature,saved,conserved,dry,fresh,guaranteed,safe,cured,secured,dried
 volunteering	furnishing,giving,presenting,issuing,suggest,providing,contributing,offering
 counsel	lawyer,counselor,advocate,attorney
-ge	
 semiconductor	transistor,conductor,diode,chip
 is	lives,rules,exists,continues
-salem	
 fire	occurrence,light,shoot,explosion,attack,heat,terminate,drop,blaze,force,bombing,discharge,launch,happening,explode,sack
 croatian	croatia
 galway	ireland
@@ -3034,7 +2861,6 @@ bungalow	farm,shack,shelter,castle,house,place,duplex,ranch,chalet,farmhouse,cot
 era	term,age,time,stage,generation,cycle,period,epoch,day,year
 likely	prone,potential,expected,probable,feasible,possible,inclined,likelihood,apt,reasonable,promising,acceptable,inevitable,fair
 fictional	phantom,fantastic,invented,ideal,imagined,unreal,legendary,imaginary,theoretical,fabricated
-thumbs	
 saws	words,proverbs
 maximizing	expanding,increasing,enhancing,swelling,extending
 riddle	gravel,complexity,beat,dilemma,puzzle,mar,mystery,pepper,corrupt,get,pose,stick,problem,secret,why
@@ -3064,7 +2890,6 @@ dreamed	featured,saw,pictured,reflected,imagined,conceived
 identify	name,determine,find,analyze,diagnose,classify,investigate,distinguish,finger,locate,describe,tell,select,spot,establish,place,differentiate,separate,recognize,id
 oceans	holes
 squared	consisted,fit,matched,aligned,checked,sorted,agreed,answered,fitted,went
-adams	
 traders	merchant,vendors,entrepreneurs,buyers,dealer,retailers,seller,dealers,merchants
 parental	maternal
 declared	proclaimed,definitive,sure,certain,announced,definite,alleged,complete,stated,exhaustive,express,comprehensive,explicit,specified,asserted,specific
@@ -3087,16 +2912,13 @@ court	propose,palace,praise,woo,judge,tribunal,charm,sue,courtroom,castle,courth
 compressed	rigid,tough,strong,filled,crowded,limited,closed,solid,small,precise,full,arranged,condensed,stuffed,firm,stiff,sturdy,wrapped,hard,brief,dense,compact,loaded,heavy,close,tight,thin,decreased,abundant,opaque,diminished,definite,crisp,slender,substantial,slim,deep,thick
 prohibition	suppression,injunction,decree,ban,exclusion,banning,restriction,veto,fiat,constraint,taboo,order,prevention
 fakes	copies,reproductions
-armstrong	
 poppy	heroin,drug,flower
 encourages	restore,develop,further,aid,inspire,promote,support,favor,boost,reinforce,ease,strengthen,spur,assist,invite,advocate,improve
 verified	validated,proved,very,confirmed,proven,true,convincing,real,authenticated,documented,effective,authentic,factual,realistic,actual,concrete,genuine,valid,established,demonstrated
 proportion	bulk,dimension,volume,ratio,capacity,coherence,content,balance,proportional,correlation,symmetry,distribution,percentage,unity,fraction,rate,symphony,scope,portion,harmony,magnitude,scale,equilibrium,share,percent
 purse	money,pouch,bag,wallet,wealth,clutch,prize,reward,gift,pocket,handbag,container
-east	
 ip	informatics,computing,science
 outlaw	prevent,exclude,ban,veto,prohibit,bar
-ai	
 partnership	corporation,relation,connection,union,relationship,solidarity,friendship,association,firm,sharing,dealings,partner,interaction,company,collaboration,society,organization,assistance,alliance,liaison,cooperation,affiliation,business,cooperative,interest,merger,ownership
 cloth	denim,pick,velvet,hem,elastic,fiber,felt,knit,wool,fibre,goods,net,canvas,tweed,diaper,screening,jean,lame,textile,linen,silk,satin,tammy,acrylic,quilting,suede,filling,waterproof,cotton,plush,tapestry,mesh,polyester,cashmere,plaid,hair,aba,duck,velcro,web,macintosh,nylon,metallic,network,warp,stuff,terry,motley,material,lace,rep,fleece,canopy,cord,coating,fabric,print
 shopping	spending,browsing,marketing,crossing,purchasing
@@ -3129,7 +2951,6 @@ lucent	liquid,transparent,crystal,sheer,clear,bright
 deductions	discounts,reductions,rebates
 illusion	nightmare,myth,mirage,visualization,fantasy,deception,fiction,idea,phantom,dream,shadow,imaging,vision,confusion,image
 sciences	data
-raleigh	
 cosmic	giant,large,good,vast,galactic,tremendous,mighty,astronomical,mega,huge,enormous,big,massive,grand,planetary,jumbo,gigantic,oceanic,global,titanic,bumper,major,mammoth,super,infinite,considerable,heroic,monster,great,substantial,immense
 graduating	presentation,introduction,launching,appearance,opener,beginning
 altitude	ceiling,peak,height,elevation,level,distance,inches
@@ -3183,7 +3004,6 @@ ac	element
 driveway	road,route,turnaround
 cardiff	wales
 milk	beverage,extract,leverage,protein,cream,cheat,drain,bleed,drink,pimp,work,use,manipulate,skin,exploit,abuse
-guinness	
 attracted	anxious,passionate,enchanted,vigorous,keen,charmed,occupied,absorbed,concerned,thrilled,avid,interested,involved,pleased,inspired,sympathetic,responsive,hooked,earnest,impressed,obsessed,drew,eager,warm,willing,excited,delighted
 comfortably	easily,adequately,fine
 surrounded	embraced,enclosed
@@ -3208,7 +3028,6 @@ releasing	expressing,unlocking
 bib	apron,drink,soak
 cerebral	cultured,educated,academic,analytical,scholarly,intellectual,intelligent,blue
 generic	overall,collective,universal,product,merchandise,broad,common,comprehensive,extensive,ware,wide,blanket,global,widespread,wholesale,general
-creatine	
 determination	resolution,discovery,finding,locating,confidence,certainty,location,find,assurance,validation,persistence,designation,courage,solving,judgment,proof,identification,granite,dedication,energy,readiness,decision,localization,resolve,conviction
 serpent	boa,cobra,python,viper,snake
 upgrading	promotion,creation,advance,rise,advantage,growth,priority,elevation,improvement,upgrade,advancement
@@ -3222,7 +3041,6 @@ emotions	habit,personality,sense,chords,humor,nature,ego,intellect,attitude,char
 skateboard	board
 tuning	merging,evening,supervision,control,matching,blending,adjustment,arrangement,settlement,coordinating,standardization,management,governance,balancing,combining,conforming,integrating,connecting
 depend	stay,hinge,ride,rest,base,establish,found,be,hang,turn
-s	
 stores	supplies,funds,payment,collections,banks,reserves,responsibility,relief,deposits,subsidy,care
 agencies	company,departments,services,department,branches,firm,divisions,organ,bureau,desks,offices,force,operation,office
 employ	engage,apply,reuse,assume,spend,implement,misuse,work,pay,avail,retain,commit,enjoy,ply,use,hire,resort,fee,utilize,address,assign,play,strain,exploit,waste,exercise,handle,take,practice,occupy,recycle,operate,extend,overdrive,put,place,share,recruit,give,hold
@@ -3241,7 +3059,6 @@ annoying	disturbing,frustrating,painful
 mock	parody,insult,rally,guy,rib,ride,rag,bait,simulated,perform,play,tease,do,bogus,handle,treat,cod,simulate
 panic	scare,alarm,fear,rush,anxiety,horror,terror,concern,dread,frenzy,confusion,worry
 alaska	usa,hubbard,anchorage,america,ak,us
-ibid	
 dishes	glassware,plates,trays,fare,cooking,servers,menu,vessels,meal,bowls,cups
 seminar	workshop,panel,symposium,convention,course,discussion,meeting,conference,class,forum,roundtable
 celebrities	popularity,names,personality,hero,figure,celebs,personalities,someone,star,superstar,figures,stars,lights,heroes,icons
@@ -3255,7 +3072,6 @@ electrical	inspiring,breathtaking,exciting,stirring,interesting,fascinating,intr
 sin	error,offence,debt,wrong,crime,felony,lust,offense,violation,guilt,evil,fault,breach
 gave	permit,presented,awarded,apply,donated,issued,read,return,open,do,present,award,deliver,contributed,lend,furnished,produce,commit,grant,provide,express,accord,issue,lead,provided,allow,go,address,fail,sell,offer,cause,rendered,afforded,make,show,extend,throw,put,offered,announce,donate,turn,indicate
 landscapes	scene,photograph,painting,view,scenery
-alprazolam	
 oceania	pacific,polynesia,micronesia
 undefined	misty,dark,faint,opaque,pale,obscure,fuzzy,dim,vague,ambiguous,unclear
 lying	false,erroneous,fabrication,misleading
@@ -3283,7 +3099,6 @@ attitudes	bias,behaviors,stance,view,mood,approach,notion,sentiment,opinion,mann
 aqua	juice,turquoise,rain,drink,vapor,blue
 sally	odyssey,excursion,input,tour,voyage,crack,spin,expedition,journey,outing,remark,walk
 strait	roads,arm,stretch,sound,gulf,channel,neck,narrow,inlet,bay
-oliver	
 featured	identified,displayed,advertised,emphasized,stressed,illuminated,highlighted
 hence	accordingly,consequently,thus,therefore,so,thence
 ruby	glowing,gem,maroon,coral,bloody,flaming,crimson,cardinal,red,rose,wine
@@ -3294,10 +3109,8 @@ dull	quiet,arid,flat,simple,soft,dark,blunt,obscure,dim,dry,slow,ordinary,cloudy
 fixtures	machinery,apparatus,housewares,gear,furnishings,material,institutions,equipment,symbols,plumbing,furniture,icons
 alerts	inform,signal,notifications,alarm,warnings,notices,advice,suggestions,alarms,recommendations,notify,predictions
 plausible	logical,practical,convincing,compelling,strong,possible,pat,probable,reliable,credible,valid,likely,effective,reasonable,acceptable,satisfying
-santa	
 basal	underlying,essential,basic,elemental,fundamental,beginning,introductory,elementary
 thing	personality,mortal,point,guy,human,customer,thought,doing,person,phenomenon,being,attitude,work,object,feature,detail,bird,fact,party,factor,fish,devil,piece,scout,action,face,information,accomplishment,individual,job,baby,character,specimen,situation,element,event,subject,item,task,duck,body,business,egg,matter,man,stuff,anything,happening,everything,soul,material,word,cookie,life,concept,concern,creature,quality,part,sort
-barbados	
 interactions	synergy,dealings,cooperation,relations,communication
 thresholds	points,edges
 shack	tent,cabin,camp,hut,shed,cottage,shelter
@@ -3312,7 +3125,6 @@ olympus	greece
 afghanistan	asia,afghan
 baking	lighting,firing,boiling,biscuit
 reds	rebels
-macs	
 corn	bump,ear,sludge,berry,drink,sore,maize,rubbish,spirits,rice,alcohol,barley,liquor,grain,goo,hay,food,popcorn,inflammation,injury,meal,egg,tumor,cereal,nut,spike,wheat
 increments	rises,gains,supplements,additions,more,raises,increases
 inference	judgement,consequence,assumption,decision,interpretation,conclusion,deduction,analogy,verdict,reasoning,induction,diagnosis,determination,implication
@@ -3324,7 +3136,6 @@ alive	animated,lively,vital,conscious,viable,eager,live,ready,life,breathing,ani
 streets	ways,avenues,roads,pike,routes,drives,arteries,highways,rows,lanes,passes
 opened	staring,slipped,open,wide,unlocked
 qatar	arabia
-an	
 coil	fun,zoo,clutter,din,storm,hurry,hurricane,noise,stew,disturbance,bother,row,turn,stir
 built	improved,plump,stout,stacked,ripe,overweight,chubby,round,gross,obese,ample,fat,thick,full
 ohio	mansfield,akron,midwest,oh,toledo,usa,america,athens,cleveland,dayton,cincinnati,columbus,us
@@ -3339,10 +3150,8 @@ freeze	fix,concrete,chill,set,suspend,gel,ice
 across	around,through,over,transverse
 professional	specialist,paid,educated,proficient,qualified,expert,competent,licensed,veteran,efficient,technical,experienced,pro,artist,specialized,skilled
 novelty	souvenir,innovation,curiosity,departure
-taliban	
 crane	develop,lift,open,hike,expand,enhance,increase,draw,reach,go,raise,fill,last,up,run,stretch,strain,grow,continue,take,cover,boost,pull,enlarge,spread,span,swell
 epoxy	glue,paste,adhesive,size,mud,sand,plaster,cement,gum,bond
-jefferson	
 output	labor,produce,yield,production,fruit,productivity,product,result,manufacturing,profit,work,gain,harvest,amount,crop,outcome
 resort	park,lodge,apply,camp,utilize,motel,refuge,inn,harbor,spot,hotel,club,clubhouse,employ,retreat,haven
 chronicles	memoirs,stories,witnesses,versions,accounts,diaries,tales,records,reports,annals,histories,commentaries
@@ -3356,7 +3165,6 @@ speaks	declare,puts,talk,shout,communicate,shouts,deliver,announces,argue,shares
 accountable	obliged,responsible,liable
 pizza	dish
 luggage	imperial,grip,bag,wallet,strap,gear,bags,trunk,handle,kit,case,handbag,baggage,hold
-marcel	
 grains	parts,nuggets,portions,sections,fragments,particles,atoms,bits,scraps,traces,snippets,fractions,bites,molecules,drops,ounces,patches
 intense	overwhelming,extraordinary,harsh,smart,strong,bitter,excessive,intensive,violent,profound,vicious,keen,extreme,grade,wild,exquisite,brutal,degree,big,powerful,acute,hard,main,furious,utmost,concentrated,cold,energetic,vivid,heavy,severe,sharp,terrific,raging,explosive,fierce,bad,wicked,great,screaming,terrible,level,consuming,deep,thick
 wei	dynasty
@@ -3396,7 +3204,6 @@ people	mortal,grouping,handicapped,folks,generation,world,humans,land,somebody,p
 cradle	birthplace,home
 accesses	fits,seizures,turns,cases,attacks,spells
 windsor	elizabeth,edward,george,dynasty
-deco	
 probes	investigations,inquiries,examinations,surveys,inspections,studies
 dementia	instability,mania,insanity,madness,schizophrenia,rage
 infect	soil,rot,conduct,corrupt,poison,transmit,communicate,stain,convey,touch,spread,foul,transfer,give,affect,dirty
@@ -3445,9 +3252,7 @@ entering	invasion,attack,enrollment,accessing,entry,entrance,penetration,registr
 poverty	lack,bankruptcy,debt,misery,shortage,hardship,difficulty,emergency,deficit,want,need,necessity,deprivation
 lighted	lit,radiant,brilliant,shining,intense,shiny,sunny,flashing,vivid,light,bright,illuminated,golden,sparkling
 absorb	involve,incorporate,follow,get,consume,drink,learn,employ,sponge,swallow,understand,sip
-roosevelt	
 nest	nursery,den,seat,heart,base,focus,refuge,capital,seminary,nucleus,center,hub,core
-transvestite	
 commands	supervision,directions,determine,grasp,requirements,require,dominate,rule,words,supervise,duty,direction,order,commandments,control,direct,instructions,orders,appoint,ability,government,authority,charges,manage,request,responsibility,tell,skill,leadership,jurisdiction,directives,law,expertise,word,management,authorize,mandate,regulation
 neck	corridor,zone,tract,region,land,body,belt,throat,district
 motif	topic,matter,motive,subject,figure,theme,content,essence,idea,logo,question,concept,design,pattern
@@ -3460,7 +3265,6 @@ vineyard	manor,ranch,grange,homestead,estate,farmhouse,farm,garden,orchard,plant
 move	withdraw,swing,change,swan,steam,ferry,flow,action,career,roll,sit,angle,thread,lead,measure,fall,climb,step,journey,drift,blow,movement,weave,shift,spread,ship,replace,lift,switch,wheel,swap,wind,stray,tread,float,swim,whistle,motor,remove,accompany,go,arise,proceed,carry,transport,continue,follow,shack,seek,caravan,glide,circle,turn,do,drag,drive,forge,slide,race,automobile,leave,return,hurry,bang,push,fly,crawl,cruise,progress,bring,come,start,pan,back,bounce,walk,err,speed,travel,creep,trail,pass,repair,rove,convey,ski,procedure,retire,zip,ease,round,draw,advance,pursue,motion,cross,crank,wing,rush,jump,breeze,haul,ghost,ride,taxi,range,transfer,resort,lance,wander,flock,rise,play,convert,shuttle,beetle,circuit,pace,operate,cast,migrate,zoom,retreat,relocate,run,act
 assembled	met,collected,joined,gathered,concentrated,merged
 mine	pit,drill,shaft,repository,field,excavation,reserve,extract,quarry,store
-psi	
 cdna	dna
 restrict	define,reduce,narrow,curb,inhibit,regulate,limit,decrease
 nearest	closest,convenient,adjacent,direct,grey,inner,median,halfway,mid,central,recent,warm,intermediate,middle,cozy,confidential,loving
@@ -3468,24 +3272,19 @@ bloodhound	prosecutor,spy,reporter,agent
 temple	church,shrine,house,sanctuary,kirk,mosque,mission,chapel,abbey,cathedral
 lesions	hurts,scratches,mayhem,strains,injuries,disabilities,damages,wounds
 peru	peruvian,amazon,lima
-hyderabad	
 performed	regulated,achieved,acted,made,decided,stopped,negotiated,practiced,fulfilled,managed,resolved,accomplished,effected,closed,satisfied,committed,completed,implemented,did,ended,executed,finished,settled,full,staged,realized,concluded
 brook	tolerate,stream,creek,canal,gill,beck,burn
 shareholder	investor
 relaxed	spontaneous,detached,flexible,easy,warm,informal,calm,composed,comfortable,satisfied,casual,tolerant,resting,cozy
-simon	
 windy	winding,turning,bending
 see	hear,feature,follow,call,conduct,detect,realize,encounter,regard,show,determine,meet,think,glimpse,walk,visit,anticipate,study,feel,identify,suffer,recognize,consider,watch,witness,examine,have,catch,receive,behold,get,notice,distinguish,sight,learn,view,know,eye,look,note,lead,remark,spot,understand,discover,perceive,observe
 cookie	belle,cutie,snap,queen,cake,doll,babe,fox,biscuit,goddess,peach,kiss,honey,beauty
 pets	speeds,favorites,treasures,dog,lover,treasure,preferences
-lr	
 informatics	computing,ip,science
-cowboy	
 nearby	near,adjacent,immediate,adjoining,neighboring,close
 win	score,triumph,overcome,make,secure,carry,upset,gain,reach,have,accomplishment,catch,vie,achievement,earn,receive,get,gold,accomplish,succeed,take,sweep,beat,compete,prevail,success,conquer,achieve
 candid	vocal,plain,impartial,blunt,straightforward,direct,frank,open,honest,unbiased,forthcoming,earnest,sincere,straight
 lane	street,path,pathway,walk,drive,artery,pass,freeway,road,row,highway,pike,avenue,track,way,trail,route,roadway,approach,passage,bypass,boulevard
-scalar	
 entry	player,entrance,hall,admission,lounge,passage,door,lobby,item,registration,opening,access
 ussr	russia
 waterfront	coast,beach,riverside,border,strand,seaside,shore,shoreline,coastline,bank,sand
@@ -3500,7 +3299,6 @@ tricks	schemes,devices
 cubic	rectangular,solid,square
 sensor	detector
 benches	judges,courts
-modernization	
 knocked	impacted,crashed,hit,struck
 cl	mil,dl,ml,cc
 gigantic	substantial,enormous,mighty,heroic,massive,bumper,oceanic,huge,vast,planetary,titanic,grand,great,giant,large,majestic,monster,big,mega,considerable,mammoth,tremendous,cosmic,galactic,oversized,super,astronomical,jumbo,immense
@@ -3509,7 +3307,6 @@ roanoke	virginia
 medications	pills,cure,remedy,prescriptions,aid,treatment,prescription,antibiotics,pharmaceuticals,drug,placebo,remedies,assistance,medicine,pill,drugs,physics,pharmaceutical,medicines
 disconnected	confused,meaningless,confusing,detached,inconsistent,split,absurd,ridiculous,strange,weird,separated,frustrating,silly,foolish,unusual,bizarre,curious
 resorts	clubs,camps
-gps	
 programmer	hacker,operator,cracker,technician,engineer
 slice	shave,hack,share,sampling,split,sample,part,percentage,strip,portion,sampler,selection,slash,piece,wedge,divide
 aisle	lane,corridor,path,avenue
@@ -3565,7 +3362,6 @@ organizations	business,circle,club,society,chambers,consortium,management,indust
 template	guide,example,model
 azerbaijan	cis
 selection	vote,ballot,voting,collection,election,pick,choosing,decision,determination,picking,excerpt,choice,option,action,conclusion,casting,draft,sampling,selecting,willing,nomination,appointment
-metabolic	
 choir	wait,ensemble,chorus,shout,quartet,whistle,orchestra,cast,band,trio,hum
 spark	shine,initiate,occur,sparkle,glitter,trigger,flash,pass,hint,pioneer,stimulate,flare,trip,stir,activate,glow,flame,burn
 carrot	title,crown,premium,remuneration,championship,encouragement,purse,advantage,citation,value,coupon,dividend,reward,herb,stock,award,gain,fee,profit,benefit,honor,jackpot,reason,gold,motivation,bounty,surplus,trophy,compensation,scholarship,stimulus,medal,bonus,proceeds,allowance
@@ -3606,7 +3402,6 @@ heather	grey,colour,color,dusty
 corresponding	reciprocal,parallel,matching,related,alike,akin,like,identical,correspondent,analogous,such,twin,similar,equivalent,comparable
 holiday	break,anniversary,celebration,gala,honeymoon,picnic,recess,festival,outing,feast,leave,vac,leisure,vacation
 certificate	warranty,commission,authorization,authentication,probate,coupon,document,ticket,papers,guarantee,registration,paper,diploma,warrant,certification,permit,credentials,license,affidavit,deed,voucher,documentation,receipt
-ida	
 parents	fathers,moms,dads,mothers
 photograph	stereo,image,shoot,picture,enlargement,still,mosaic,capture,representation,pic,shot,illustrate,snapshot,portrait,print,scene,photo,blueprint,glossy,reproduce,frame,exposure
 entertaining	funny,exciting,humorous,fun,impressive,engaging,absorbing,pleasant,delightful,affecting,fascinating,interesting,nice,lively,stimulating,moving,inspiring,charming,amusing,compelling,enjoyable
@@ -3707,7 +3502,6 @@ already	once,shortly,now,before,previously,then,soon,earlier,early,formerly,ahea
 fashionable	swell,elegant,trendy,fresh,latest,new,cool,happening,modern,upscale,mod,groovy,in,contemporary,spruce,smart,stylish,exclusive,sophisticated,handsome,hip,graceful,popular,chic,haute,hot
 black	brunette,onyx,dark,raven,jet,ebony
 invoices	documents,receipts,records,prices,accounts,checks,statements,tabs,bills,fees,rates
-berkeley	
 gets	sees,hears,knows,understands,masters,learns,discovers
 tipping	pitched,oblique,listing,crazy,crooked
 freaks	monsters,abnormalities,exceptions,mutants,mutations,anomalies
@@ -3748,7 +3542,6 @@ sox	stocking,hose
 entirety	completeness,works,perfection
 reward	repay,dividend,honor,wages,premium,remuneration,profit,consequence,award,compensate,prize,bounty,bonus,price,compensation,benefit
 tobacco	filler,cigarette,nicotine,smoke,crop,smoking
-bamboo	
 sensing	diagnosis,informed,introduction,careful,feeling,encounter,learning,rational,tasting,expecting,experienced,knowledgeable,educated,perception,detection,realizing,smart,hearing,seeing,thoughtful,disclosure,revelation,analysis,sensible,noting,aware,exploration,prudent,discovering,sane
 sixty	cardinal,lx
 assurance	assertion,pledge,confidence,guarantee,security,certainty,authority,conviction,satisfaction,support,promise,uncertain,unsure,word,sure
@@ -3759,7 +3552,6 @@ virus	infection,cancer,illness,toxic,poison,disease,vector,sickness
 installing	initiating,place,plant,beginning,institute,commencement,lay,seating,invest,investing,receiving,fix,introduce,start,station,installment,installation
 caravan	expedition,parade,train,fleet,armada,line
 confused	messy,lost,nasty,chaotic,dirty,stained,spotted,filthy
-serbian	
 biopsy	test,probe,observation,inquiry
 judging	concluding,hearing,determining,judgement,resolving,deciding,settling,weighing,considering
 unveiled	solved,disclosed,naked,detected,defined,helpless,raw,stripped,resolved,uncovered,invented,identified,exposed,discovered,bare
@@ -3815,7 +3607,6 @@ tune	lay,line,idea,piece,phrase,voice,concert,composition,music,song,air,hymn,ji
 tomb	pit,place,burial,cemetery,spot,vault,coffin,monument,grave,crypt
 variety	diversity,variation,character,accumulation,aggregation,mixture,collection,change,nature,quality,sampler,brand,range,array,kind,selection,strain,category,description,motley,assortment,soup,breed
 ranges	scope,go,yards,space,line,cover,vary,collection,field,spread,reach,stretch,variety,lot,sort,drift,area,dimension,kind,selection,differ,territory,matter,assortment,spectrum,length
-minimizing	
 opus	quartet,sketch,masterpiece,piece,octet,study,solo,number,finale,composition,pastoral,suite,music,song,vocal,realization,work,arrangement,medley,canon,movement,largo,passage,trio,duo
 coordinate	organize,match,arrange,accommodate,suit,mesh,adapt,agree,connect,conform,regulate,merge,organise,align,combine,integrate
 barely	somewhat,almost,hardly,just,nearly,scarce,slightly
@@ -3838,7 +3629,6 @@ formulas	arrangements,procedures,processes,designs,recipes,methods,programs,stra
 penn	pa,pennsylvania
 indicates	show,signifies,make,imply,hint,denotes,mean,express,reveal,illustrate,announce,specify,argue,mark,prove,means,suggest,demonstrate,signal
 tap	pound,bat,drum,pump,rap,pat,open,hit,bang,slam,knock,click,valve,beat,utilize,draw,tip,touch,strike,hammer
-patriots	
 verses	lyrics,songs,poems,rhymes
 dance	ball,reception,celebration,disco,gala,samba,hop,event,waltz,festival,party,prom,formal,tango,move,step
 assets	capital,money,resources,share,possessions,property,effects,amount,finances,riches,wealth,portion,holdings,possession,things,worth,credit,resource,funds,protection,sum,part,percentage,substance,fortune,savings,investment,means,intangible,security,equity
@@ -3886,7 +3676,6 @@ yin	principle
 sign	clue,logo,subscribe,warning,endorse,trace,gesture,hint,symptom,autograph,emblem,light,type,wave,ink,token,notice,register,mark,symbol,pen,flag,proof,prediction,suggestion,note,signal,confirm,author
 judgment	intelligence,persuasion,awareness,experience,conviction,ruling,idea,holding,sentiment,doom,award,opinion,decision,evaluation,determination,intuition,scrutiny,knowledge,perception,sense,understanding,finding,injunction,result,judgement,sentence,analysis,view,conclusion,wisdom,inquiry,resolution,observation,verdict,belief,assessment,review,order,appraisal,reasoning,decree,mind,thought
 handwriting	scratch,manuscript,print,signature,autograph,writing,hand,script
-unanswered	
 seasonal	persistent,periodic,yearly,intermittent,weekly,conventional,serial,unusual,different,alternating,miscellaneous,repeated,repetitive,alternate,continual,occasional,eternal,normal,routine,usual,monthly,continuing,recurrent,cyclic,chronic,everyday,regular,annual,periodical,recurring,ordinary
 september	sept,sep
 scientology	faith
@@ -3896,10 +3685,8 @@ hotel	building,court,house,tavern,hospice,accommodations,spa,motel,lodging,campg
 conservatives	rights
 churches	temples,missions
 signal	cue,retreat,output,whistle,input,recording,communication,beam,number,noteworthy,beacon,gesture,alarm,sign,signaling,start,indicator,noticeable,symbol,flag,alert
-xanax	
 urges	ask,advise,prompts,promote,pushes,force,endorse,favor,weakness,lust,appetite,impulse,recommend,encourages,prompt,propose,spurs,advocate,request,press,passion,push,support
 heroes	models,classics,icons,gods,ideals
-unix	
 hold	distance,cradle,operate,call,own,bear,conserve,run,continue,remain,handle,dominance,grip,carry,stay,include,influence,preserve,have,arrest,clutch,celebrate,enjoy,last,take,occupy,buy,grab,keep,seize,maintain
 bitter	mad,vicious,hard,biting,fierce,harsh,cruel,intense,sharp,brutal,angry,severe,savage,unpleasant,sore,bad,disturbing,sour
 fha	liberty,autonomy
@@ -3909,7 +3696,6 @@ lure	call,persuade,stimulate,bait,trap,hook
 rake	comb,heel,rip
 traditions	culture,norms,lore,prescriptions,principles,idea,heritage,institution,practice,form,legend,rules,custom,myth,values,standards,conventions,customs,ritual,habit,folklore,ethics,attitude,wisdom,law,belief,mythology
 pat	strict,hard,persistent,determined,stern,chuck,iron
-prague	
 quantity	bucket,quantum,loads,myriad,yard,mess,value,amount,hundred,volume,measure,much,interval,play,load,chunk,peck,chance,abundance,capacity,pack,portion,wealth,dozen,pot,pile,excess,barrel,deal,size,variety,lot,sum,plenty,sight,surplus,mass,standard,bundle,batch,bulk,metric,bunch,stack,thousands,heap,mountain,abstraction,proof,ton,quota,radical,probability,length,store
 conceptual	spiritual,abstract,hypothetical,ideal,theoretical,visionary,mental,intellectual
 enquiries	query,inquiry
@@ -3922,7 +3708,6 @@ multicultural	multilateral,continental,global,multinational,international,extern
 ultrasonic	accelerated,prompt,immediate,swift,rapid
 pine	fear,stress,long,worry,despair
 belong	apply,exist,go,place,reside,stay,fit,be
-fema	
 fuller	clear,generous,whole,exhaustive,absolute,filled,extensive,rich,comprehensive,complete,stuffed,loaded,sufficient,entire,packed,detailed,big,broad,maximum,perfect,intact,stocked,crowded,adequate
 applet	application
 implementations	accomplishments,applications,performances,achievements
@@ -3936,7 +3721,6 @@ strictly	closely,carefully,precisely,exactly
 competency	expertise,fitness,capacity,proficiency,capability,talent,competence,ability,skill,faculty
 academic	lecturer,scholar,professor,scholarly,abstract,hypothetical,collegiate,student,theoretical,educational,intellectual,scholastic
 excerpts	extracts,snippets,citations,clips,passages,quotations,samples
-tate	
 walk	gimp,pound,move,course,mouse,road,tread,travel,wander,race,lead,tip,tour,wade,lumber,trek,paddle,trail,go,hike,parade,pad,run,pace,limp,sneak,creep,step,foot,street,track,stamp,stroll,march,path,toe,stretch,shuffle,reel,process,tap,hitch
 enjoying	enjoyable,pleased,convenient,happy,happiness,loose,liking,relaxed,relaxation,useful,loving,digging,cozy,satisfying,amusement,warm,recreation,joy,thrill,appropriate,luxury,healthy,pleasant,easy,soft,satisfaction,fun,pleasure,indulgence
 specifications	proposal,intent,map,aim,means,way,technique,platform,diagram,policy,tactic,intention,purpose,idea,conception
@@ -3950,7 +3734,6 @@ exposed	bare,defined,liable,susceptible,solved,open,endangered,prone,discovered,
 provisional	alternate,temporary,conditional,transitional,interim
 husbands	mates,men,partners,companions,spouses
 riley	sore,furious,ballistic,mad,passionate,angry,hot,annoyed
-ironically	
 employees	university,institute,staff,colleagues,society,club,workers,guild,association,federation,league,hands,personnel,associates,local,department
 anxious	troubled,upset,restless,dying,distressed,nervous,disturbed,worried,keen,scared,tense,concerned,careful,enthusiastic,bothered,obsessed,afraid
 shine	glow,flare,sparkle,blaze,fire,flame,light,gloss,burn,glitter,blink,reflect,beam,ray,flash
@@ -3984,11 +3767,9 @@ buster	someone,soul,person,sir,master,individual,buddy,cat,guy,male,mister,dude,
 prototypes	specimens,indications,representatives,examples,instances,illustrations,cases,precursor,model,samples
 installment	installation,baptism,repayment,episode,chapter,inaugural,installing,portion,start,payment,beginning,commencement,initiation,investment
 suitable	convenient,relevant,proficient,competent,expert,proper,qualified,useful,apt,skilled,capable,correct,good,reasonable,fit,satisfactory,equal,able,experienced,prepared,applicable,ready,handy,fitting,suited,sufficient
-hampshire	
 dm	diabetes
 bullock	cows,steer,male,cattle
 outfits	dresses,costumes,apparel,closet,dresser,trunk,clothes
-shakespeare	
 sort	comb,brand,model,arrange,stripe,quality,kidney,form,manner,character,set,like,category,flavour,array,breed,catalogue,flavor,make,type,description,genus,species,nature,lot,separate,variety,style,genre,number,kind,color
 receiving	welcoming,taking,entering
 eleven	xi,cardinal
@@ -3997,7 +3778,6 @@ surfers	browsers
 specify	establish,limit,order,indicate,provide,arrange,determine,mention,prescribe,tell,fix,define,qualify,cite,condition,direct,contract
 pundit	intellectual,philosopher,sage,expert,wizard,scholar,professor,initiate,buff,teacher
 photo	icon,statue,picture,print,account,copy,art,shoot,impression,scene,painting,blueprint,pic,cartoon,figure,capture,decoration,engraving,glossy,enlargement,piece,report,drawing,description,portrait,representation,photograph,shot,frame,still,exposure,mosaic,reproduce,stereo,illustrate,image,sketch,snapshot
-baccarat	
 came	approached,entered
 wage	pay,salary,payroll,payment,found,remuneration
 utopia	nirvana,paradise,zion,sion,heaven,bliss,eden,wonderland
@@ -4009,7 +3789,6 @@ sonic	neural,auditory,sensual,visual,audible,neurological
 jerry	german,hun
 tissue	pattern,thread,balance,stuff,ornament,screen,goods,flesh,quality,stationery,mesh,taste,character,note,grain,poster,sense,net,sheet,card,towel,network,being,surface,pad,organism,meat,material,feeling,nature,touch,makeup,cotton,structure,band,consistency,fabric,composition
 independently	separately,freely,solely,alone,individually
-verona	
 streamline	establish,place,distribute,simplify,integrate,mold,forge,fashion,consolidate,file,facilitate,construct,build,conduct,frame,plan,reduce,clarify,produce,assign
 sheriff	captain,copper,police,officer,cop,inspector,marshal,detective,investigator,lieutenant,sergeant,marshall
 look	show,attention,appear,consider,sound,seek,act,eye,review,gaze,study,manner,fashion,view,express,admire,hope,glance,see,make,search,glimpse,stare,watch,read,peer,peek,face,presence,notice,expression,seem,feel
@@ -4018,7 +3797,6 @@ correspond	pattern,align,tally,compare,consist,square,be,adhere,fit,match,write,
 liberation	parole,relief,achievement,probation,freedom,democracy,accomplishment,clearing,sovereignty,salvation
 contextual	place,ambient,climate,element,surround,surroundings,medium,terrain,environment,dependent,setting,backdrop,situation,space,atmosphere,location
 disciplines	territories,circles,preparation,businesses,education,lines,specialties,realms,walks,spheres,areas,domains,control,professions,subjects,elements,fields,development,games,provinces,fronts,departments,studies,method,will,practice,restraint,regulation
-kiwi	
 arts	linguistics,trades,crafts,discipline,field,philosophy,history,humanities,study,trivium,chronology,subject,skills
 reduction	cut,contraction,drop,depreciation,depletion,relief,abatement,mitigation,deduction,amortization,lowering,rebate,moderation,discount,decrease,shelter
 closed	decided,sealed,exclusive,shut,locked,unavailable,settled,restricted,concluded,private,ended,resolved,limited,blocked
@@ -4038,7 +3816,6 @@ democrat	representative,pol,socialist,leader,senator,president,politician
 restaurants	cafeteria,inn,diner,joint,cafes,saloon,diners,outlet,bar,grills
 conformity	agreement,harmony,correspondence,compatibility,accordance,accord,conformance,tune
 consistently	usually,often,constantly,commonly,continually,regularly,normally,frequently,continuously,routinely,steadily,forever,ever,typically,repeatedly,always
-catalan	
 approximately	generally,much,almost,near,roughly,say,relatively,some,nearly,about,around,like
 swan	stroll,pen,lazy,fool,rest,lag,mess,monkey,relax
 museum	salon,library,foundation,hall,exhibition,collection,building,archives,gallery,institution,deposit
@@ -4052,11 +3829,9 @@ guard	observer,keeper,secure,guardian,porter,defender,observe,sentinel,safeguard
 generosity	philanthropy,gift,kindness,goodness,bounty,generous,hospitality
 struggled	try,tackle,seek,cope,compete,strive
 feeding	sustaining,gardening,consumption,serving,bite,tasting,uptake,waiting,chew,browse,grazing,breeding,boarding,dining,culture,meadow,intake,agriculture,cultivation,catering,filling,grass,provisioning,browsing,production,eating
-polk	
 tummy	waist,belly,gut,stomach,crop
 genealogy	lineage,breeding,genetics,descent,birth,stock,extraction,tribe,kin,pedigree,line,family,blood,ancestry,origin,clan
 foreclosure	proceeding
-franc	
 directorate	commander,ministry,boss,official,manager,officer,administrator,leader,chief,authority,jury,committee,government,entrepreneur,panel,executive,management,director,administration,supervisor,board,cabinet
 classify	place,distribute,compare,sort,list,order,size,arrange,peg,identify,organize,distinguish,range,rank,allocate,compartment,file,divide,catalog,catalogue,type,label,isolate,count,class,digest,analyze,group,separate,stamp,grade,number,recognize,refer
 glucose	sugar,starch
@@ -4066,13 +3841,10 @@ faux	unreal,artificial,manufactured,bogus,imitation,fake,simulated,synthetic,sub
 separates	leave,isolates,split,splits,divide,disconnect,parts,divorce,pulls,break
 sensors	alarms,detectors
 yugoslav	yugoslavia,european
-who	
 evil	ugly,pain,bad,darkness,suffering,corrupt,corruption,dark,harm,destructive,hatred,sin,unpleasant,black,malicious,wrong,offensive,misery,vicious,wicked,sinister,crime,ill
 misty	smoky,muddy,rainy,thick,cloudy,fuzzy,overcast
-iv	
 dent	pocket,depression,turn,trench,hole,impression,excavation,bowl,valley,hit,cave,ditch,pit,recess,hollow,cavity,twist,flex,groove
 choose	draw,love,extract,appoint,screen,sort,follow,nominate,name,elect,determine,dial,specify,fix,propose,embrace,set,plump,want,field,go,tag,select,take,define,accept,panel,prefer,judge,pick,cast,limit,excerpt,designate,favor,adopt,vote,decide,assign
-diabetic	
 psychiatric	cerebral,intellectual,subjective
 obscene	dirty,coarse,nasty,abusive,unwanted,outrageous,blue,unpleasant,filthy,foul,crude,stag,offensive,gross,shocking,unacceptable,horrible,naughty,improper
 shoulders	assumes,backs,competitor,player,professional,accepts,animal,sport,bears
@@ -4100,7 +3872,6 @@ alpine	highland
 angle	phase,perspective,direction,corner,part,variation,lead,dip,view,edge,standpoint,hand,az,twist,viewpoint,intersection,aspect,fork,side,space
 amp	a,motive,drive,stimulate,brace,inspire,spike,ma,stir,activate,fire,cheer,motivate,trigger,awake,lift,excite
 gentlemen	lords,princes,knights,peers
-ohm	
 tv	tube,cable,video,sound,television,picture,audio,hdtv
 bullets	missiles,balls,shots,shells,rounds,cartridges,loads
 rhetoric	wind,style,gas,nonsense,blah,jazz,rant
@@ -4138,7 +3909,6 @@ receiver	aerial,tv,wireless,antenna,television,tuner,radio,set
 herb	dressing,sauce,salt,tree,vine,salad,pepper,sage,basil,weed,cannabis,flower,hemp,mint,spice,additive,rosemary,tea,grass,perennial,produce,blossom,rue
 desirable	beneficial,preferable,desired,wanted,acceptable,useful,worthwhile,profitable,fascinating,hot,helpful,preferred,attractive
 scrap	refuse,junk,discard,hunk,chunk,fragment,trash,stub,remainder,grain,ditch,piece,rest,dispose,end,lump,toss,dismiss,remains,reject
-tenth	
 prohibited	illicit,unlawful,taboo,barred,restricted,unacceptable,illegal,forbidden,improper,unauthorized,banned
 happily	freely,gladly
 amend	help,change,improve,restore,modify,educate,revise,upgrade,perfect,fix,develop,repair,raise,doctor,alleviate,down,relieve,polish,condition,enhance,advance,build,refine,aid,alter,better,reform,lift,remedy
@@ -4164,7 +3934,6 @@ coupon	check,ticket,certificate,pass,card,voucher,advertisement
 quilt	bedding,comfort,puff,blanket,clothes,comforter
 fittings	harness,outfit,couch,desk,apparel,hardware,gear,stuff,tools,goods,accessory,accessories,tackle,equipment,baggage,table,facilities,appliance,furnishings,sofa,apparatus,instruments,attachments,kit,luggage,chair,supply,instrument,material,machinery,furniture,bed,appliances
 lightweight	slender,fragile,tiny,little,light,small,thin,slim
-madagascar	
 recursive	circular,repeated,recurrent
 wilton	rug
 survival	existence,living,viability,animation,life,durability,endurance,persistence,continuity
@@ -4189,7 +3958,6 @@ inherited	transmitted,congenital,genetic,inherent
 alphabet	law,foundation,grammar,principles,philosophy,script,basis,basics,rule,armenian,fundamentals,elements,essentials
 redistribute	proportion,part,provide,share,distribute,appropriate,split,furnish,lot,divide,allocate,supply,assign,administer,portion,allow
 swimsuit	garment,swimwear
-dependencies	
 downtime	winter,pause,period,interruption,break
 attacker	savage,predator,offender,beast,tough,raider,wolf
 mills	workshops,plants,shops,works,factories
@@ -4201,7 +3969,6 @@ aspirations	wish,ideals,ideas,aim,aims,objects,things,dreams,desire,goals,ambiti
 endurance	patience,duration,capacity,strength,continuation,longevity,courage,tolerance,survival,durability,vitality,ability,persistence,continuity
 regal	majestic,noble,magnificent,imposing,imperial,royal
 spank	pound,kick,licking,sock,bang,belt,hack,beat,bop,bust,hit,slug,stripe,swing,hook,buffet,knee,blow,plump,switch,clip,stroke,punch,pounding,bat,knock,pick,crack,slap,bash,box,smash,rap,slam,chop,beating,lick,dab,cuff
-neuroscience	
 informative	detailed,explanatory,revealing,descriptive,advisory,instructional,educational,telling,informational,comprehensive
 destined	inevitable,coming,decided,appropriated,bound,oriented,booked,likely,possible,probable,doomed,intended,designed
 scanner	referee,reviewer
@@ -4211,11 +3978,9 @@ expressed	defined,characterized,disclosed,pictured,noted,apparent,spoken,manifes
 history	journal,annals,renaissance,record,account,past,story,documentation,chronicle,tale,relation,biography
 accomplish	conclude,implement,dispatch,attain,manage,finish,discharge,achieve,commit,perform,execute,make,run,realize,action,do,fulfill,score,negotiate,reach,effect,complete,win,produce,fulfil
 persecution	harassment,massacre,murder,imprisonment,trouble,torture,oppression,killing,disturbance,abuse,irritation,offence,anger
-pvc	
 valid	analytical,validated,sound,accurate,sensible,original,binding,compelling,good,reasonable,rational,authentic,lawful,legal,legitimate,solid,logical,true,coherent,analytic,empirical,credible
 eu	luxembourg,greece,ec,spain,nederland,europe,ireland,uk,italy,belgium,france,portugal,netherlands,germany,finland,holland,britain,deutschland,austria,denmark,sweden
 occupy	establish,involve,employ,interest,busy,conquer,work,stay,fill,capture,sit,absorb,cover,hold,attend,potter,grip,attract,maintain,engage,own,remain,keep
-jamaica	
 mature	adult,aging,bloom,aged,ripe,develop,evolve,grow,blossom,find,sophisticated,older,mushroom
 conforming	close,such,comparable,analogous,redundant,consistent,like,corresponding,twin,identical,matching,equal,approaching,parallel,duplicate,orthodox,similar,same,equivalent
 aperture	telescope,opening,hole,slot,camera,space,crack,scope
@@ -4255,7 +4020,6 @@ decorate	change,hang,grace,colour,ornament,modify,enamel,dress,trim,landscape,fl
 approaching	coming,imminent,motion,upcoming,forthcoming,move,closure,future,closing,approach,movement
 surveillance	policing,direction,stewardship,charge,leadership,inspection,oversight,control,scrutiny,monitoring,government,observing,watch,management,examination,observation,guidance,care,administration,supervision,regulation
 initiation	installation,investment,inaugural,installment,enrollment,ceremony,induction,inception,commencement,baptism
-belize	
 hooked	absorbed,curved,dependent,bent,addicted,crooked
 oversee	protect,operate,regulate,manage,govern,command,control,guide,tend,survey,direct,run,handle,administer,watch,build,conduct,supervise,keep
 archival	actual,factual,classical,real,ancient
@@ -4274,7 +4038,6 @@ galaxies	worlds,ways
 madison	wisconsin
 hearts	nuclei,seats,axes,cores,headquarters,capitals,centers,eyes,nexus,hubs,bases,focuses
 triggered	activated,pushed,generated,cause,spark,start,drove,prompt,charged,generate,powered,produce,moved,started,run,fired,ran
-lincoln	
 playa	performer,artist,drummer,musician
 towns	suburbs,municipalities,cities
 warranted	fair,suitable,legitimate,deserved,right,competent,justified,due,appropriate,legal,proper,just
@@ -4289,12 +4052,10 @@ righteous	straight,spiritual,upright,honest,ethical,good,proper,just,sound,honor
 terminology	jive,vocabulary,word,slang,language,jargon
 displays	presentation,represent,perform,act,reveal,present,exhibitions,illustrate,example,publish,demonstrate,open,demonstration,parade,promote,array,disclose,feature,shows,exhibits,flash,expose,exhibit,advertise,fairs
 transmit	convey,transport,transfer,communicate,relay,give,spread,conduct,address,translate,carry,deliver,broadcast
-toxicology	
 british	nation,country
 agents	tools,personnel,organs,ingredients,powers,influences,means,force,vehicles,instruments,agencies,crew,organization,weapons,mechanisms,ministries,factors,incentives,faculty,media,team
 nested	installed,fixed,planted
 protection	shelter,activity,insurance,safety,armor,preservation,cover,insulation,saving,security,defense,safeguard,stability,guard,weapon,care,covering,ammunition,shield,wall,ward,screen,defence,conservation,locking,charge,sealing,immunization,patrol
-infusion	
 juvenile	boy,young,teenage,youth,minor,infant,girl,adolescent
 losses	price,loss,cost,lacks,expense
 guides	advise,educate,pilots,informs,teacher,navigate,govern,trains,mentors,supervise,mentor,key,usher,engineers,oversee,shepherd,directory,influence,regulate,handbook,pilot,teaches,clue,train,manage,counselor,coaches,see,teach,shows,model,steer,tutors,accompany,escorts,handle,leads,guidebook,catalog,instruct,manual
@@ -4308,7 +4069,6 @@ pavement	street,route,asphalt,sidewalk,road,paving
 attached	caring,absorbed,beneficial,favorable,loyal,obligated,upright,inclined,dependable,generous,honest,tight,decided,rigid,involved,devoted,good,faithful,sworn,obsessed,united,merged,stable,accustomed,durable,locked,related,honorable,married,romantic,earnest,affected,sincere,welcoming,hooked,sure,pledged,established,familiar,helpful,true,dear,peaceful,passionate,responsible,thoughtful,integral,patriotic,loving,settled,warm,partial,fond,dedicated,sympathetic,connected,friendly
 against	on,upon
 aesthetics	attraction,appeal,fairness,philosophy,looks,perfection,glamour,elegance,beauty
-lily	
 lively	vigorous,live,entertaining,bright,spirit,stimulating,cheerful,alert,allegro,animated,festive,energetic,bouncing,refreshing,enjoyable,warm,spirited,alive,life
 premiums	medals,decorations,awards,accolades,honors,prizes
 kidding	gag,gossip,fun,joke,wit
@@ -4318,7 +4078,6 @@ progression	continuum,nexus,chain,evolution,string,breakthrough,train,advancemen
 velocity	acceleration,tempo,rate,pace,c,momentum,speed,hurry
 pedestrian	walker,stroller
 on	concerning,respecting,regarding,of,about,toward,towards,touching
-connectivity	
 filling	stuffing,fill,cement,dressing,padding,lining,filler,mixture,material,layer,packing
 storing	intake,keeping,result,housing,output,yield,packing,warehousing
 archiving	combining,grouping,collecting,linking,organizing,connecting,clustering,arranging,merging,compiling,joining
@@ -4329,7 +4088,6 @@ participating	affected,in,interested,distribution,concerned,allocation,accompany
 fiction	imagination,fantasy,yarn,novel,invention,tale,drama,narrative,legend,fable,utopia,book,fabrication,story,myth
 regularly	always,exactly,repeatedly,routinely,consistently,continuously,typically,constantly,continually,periodically,daily,often,systematically,frequently,commonly,steadily,usually,automatically,normally
 examples	pattern,prototypes,precedent,samples,part,representatives,specimens,symbol,cases,object,lesson,instances,case,illustrations,illustration,indications
-epsilon	
 vital	indispensable,vibrant,necessary,crucial,fit,basic,vigorous,athletic,spirited,integral,flush,capable,dynamic,decisive,healthy,strong,mighty,tough,energetic,significant,important,critical,needed,powerful,lively,meaningful,robust,imperative,urgent,fundamental,key
 radial	symmetric
 bindings	lists,tapes,belts,bands,straps,ribbons,strips
@@ -4340,7 +4098,6 @@ consolidation	synthesis,union,strengthening,combining,linking,connection,connect
 rightly	duly,adequately,happily,exactly,properly,right,appropriately,accurately,fairly,correctly,well,truly
 buried	invisible,obscure,subtle,covered,covert,concealed,unseen,trivial,wrapped,vague,hidden,faint,slender
 selling	vending,trading,business,wholesale,advertising,syndication,auction,dumping,promoting,distributing,exporting,marketing,resale,commerce,providing,sale,retail,merchandising,supplying,retailing,transfer
-sas	
 helmet	derby,hat,cap,helm,fedora,tam,hood,armor,lid,panama,beaver
 rotating	consecutive,swinging,revolving,subsequent,rolling,turning,spinning,succeeding
 hua	hum
@@ -4435,7 +4192,6 @@ earns	makes,wins,acquires,captures,achieves,gains,draws,bags,gets,lands,carries
 brochure	folder,booklet,book,leaflet,advertisement,flyer,circular
 skins	reserve,investment,note,surfaces,payment,security,stock,currency,tops,fronts,buck,shells,supply,refund,faces
 worthwhile	impressive,substantial,worthy,great,productive,invaluable,outstanding,major,serious,good,valuable,big,constructive,useful,strategic,excellent,remarkable,significant,important,much,profitable,meaningful,rewarding,historic,noble,beneficial
-addictive	
 merging	union,strengthening,synthesis,consolidation,combining,takeover,linking,connection,junction,mixture,convergence,relationship,coupling,partnership,fusion,blending,combination,blend,connecting,meeting,merger
 mushroom	accumulate,gain,wax,jump,spread,rise,enlarge,mount,expand,accelerate,boom,explode,vegetable,rocket,climb,balloon,increase,multiply,swell,surge
 pressures	force,tensions,squeeze,hardship,insist,stress,push,strains,stresses,trouble,tension,constraint,influence,strain,strength,burden,heat,press,worries,power,concerns,loads,weight
@@ -4493,7 +4249,6 @@ reptiles	dogs,heels,rats,pills,fools,snakes,beasts,idiots
 refining	purification,improving,upgrading,enhancing,processing,helping,amending
 breach	sin,disregard,break,crack,infringement,conflict,neglect,offense,violate,violation,offence
 acclaim	distinction,praise,fame,glory,recognition,props,rave,herald,applause,hail,credit,honor,sun
-anesthesia	
 map	picture,drawing,representation,plat,outline,sketch,design,chart,graph,print,plan
 aware	alive,ware,wise,familiar,sensible,sensitive,cautious,awake,consciousness,alert,informed,careful,awareness,conscious
 nerd	scholar,learner,grind,geek,genius
@@ -4504,7 +4259,6 @@ daring	hardy,heroic,bold,smart,brave,foolish
 inventories	stocks,budgets,supply,fund,index,resources,supplies,funds,reserve,pools
 duplicate	same,replication,such,equivalent,analogous,clone,copy,double,identical,matching,corresponding,repeat,comparable,equal,similar,reproduce,mirror,duplication,replica
 gears	squares,fashions,structure,fits,suits,roots,puts,doctors,conditions,tool,tunes,edits,matches,models,shapes,instrument,patterns,system
-pharmacies	
 packaging	business
 cookbook	reference,textbook,guide,text,handbook,workbook,guidebook
 reactor	coil
@@ -4515,8 +4269,6 @@ heights	spot,nirvana,highlights,high,tops,peaks,sums,paradise
 appeal	charm,suit,question,proceeding,overture,bid,desire,refer,claim,demand,propose,proposal,cry,pray,call,ask,sue,apply,application,require,petition,solicitation,plea,submit,contest,prayer,urge
 boyfriend	friend,man,boy,fellow,beau,husband,sweetheart,companion,partner,lover
 official	regulator,mandarin,minister,formal,justice,manager,valid,representative,prosecutor,registrar,administrator,ranger,proper,definite,recruiter,director,executive,provincial,officer,leader,usher,secretary,judge,agent,incumbent,fitting,authoritative,recorder,teller,commissioner,precise
-nec	
-seventh	
 since	behind,ago,below,already,later,after,following,past,therefore
 stocks	lines,blood,races,descendants,families,houses,households,people,folks,tribes
 hypothetical	proposed,theoretical,supposed,conceptual,vague,problematic,imaginary,academic
@@ -4534,7 +4286,6 @@ intellect	intelligence,nerd,mind,intuition,wizard,ability,intellectual,judgment,
 investigator	agent,inspector,scientist,analyst,examiner,detective,police,researcher,prosecutor,auditor
 enforcing	executing,application,implementing,prosecution,applying,fulfilling,administering,administration
 mouse	coward,reed,sheep
-hopkins	
 cleanup	value,coup,return,cleaning,turnout,sweeping,saving,sanitation,production,revenue,income,benefit,substitute,proceeds,percentage,order,excuse,arrange,output,trick,surplus,liquidation,harvest,apology,earnings,evacuation,product,yield,bathing,acquisition,purification,interest,goods,scrub,receipt,suppression,improvement,justification
 conceived	fabricated,hypothetical,completed,chartered,settled,unlikely,invented,theoretical,pictured,incorporated,abstract,founded,organized,unbelievable,initiated
 boxes	bins,cases
@@ -4573,7 +4324,6 @@ injustice	wrong,misconduct,breach,malpractice,prejudice,abuse,inequality,violati
 fore	forward,front,frontal,anterior
 in	via,through,by,per,inward,with
 offerings	victims,contribution,gift
-e	
 acquisition	profit,addition,return,donation,recovery,accession,acquiring,earnings,acceptance,inheritance,procurement,assumption,restoration,gain,succession,purchase,heritage,accomplishment,getting
 fatty	rich,fat
 collectable	payable,ornamental,souvenir,figurine,ornament,collectible
@@ -4610,9 +4360,7 @@ hostile	opposing,ill,dirty,offensive,malicious,opponent,opposed,nasty,mortal,con
 terrain	discipline,business,precinct,tract,sphere,front,province,contour,ground,realm,soil,land,turf,arena,kingdom,region,field,study,territory,area,parcel,circle,walk,specialty,domain,department,game,subject,element
 destination	picking,nomination,ranking,situation,delegation,end,terminal,assignment,stop,position,designation,commission,spot,station,placement,job,haven,choice,investment,harbor,election,place,target,gig,choosing,finish,office,goal,selection
 ni	nickel,metal
-egyptian	
 semi	hall,trailer,car,jeep,castle,truck,chalet,homestead,cottage,hut,van,residency,shelter,farmhouse,villa,nest,ranch,cabin,condo,rig,flat,apartment,palace,bungalow,mansion,manor,shack,wagon,crate,grange,duplex,pickup,estate,housing,accommodations
-scalability	
 attacks	seizure,criticism,offenses,violation,intrusion,charge,outbreak,attempts,hurt,bombings,offensive,storm,assault,abuse,stab,beat,blast,charges,invasion,strike,raid,blame,intervention,failure,hit,aggression,harm,offences,strikes
 visitor	traveller,company,traveler,caller,guest
 missed	ignored,skipped
@@ -4675,14 +4423,10 @@ appraiser	referee,judge,inspector,analyst,reviewer,expert,court,reporter,justice
 scholarships	literacy,education,knowledge,culture,learning
 inadequate	low,short,weak,insufficient,sad,deficient,incomplete,faulty,unacceptable,scarce,adequacy,lacking,wanting,poor,shy
 scale	rate,scope,proportion,balance,mount,extent,range,ratio,system
-colombian	
 sunflower	flower
-vietnamese	
-lira	
 readily	freely,preferably,promptly,gladly,immediately,first,easily,rather,soon,either
 stripping	occupation,tear,invasion,empty,gut,occupancy,misuse,rob,remove,withdraw,grab,infringement,expose,takeover,piracy,theft,lift
 trade	occupation,business,plumbing,craft,truck,line,industry,roofing,upholstery,enterprise,tanning,market,pottery,woodworking,transaction,swap,dealing,deal,exchange,employment,bargaining,traffic,substitution,commerce,undertaking,drafting,painting,masonry,contract,bargain
-kruger	
 overcast	dull,misty,gray,lowering,cloudy,dark,grey
 yachts	cutters,crafts,shells,vessels,gigs,ferries
 nuggets	bites,bits,tastes,snacks
@@ -4691,10 +4435,8 @@ chick	cub,chicken,girl,bud,gal,woman,teen,squirt,chap,kid,juvenile,baby,child,te
 nanotechnology	engineering
 emotionally	flaming,warm,burning,enthusiastic,intense,passionate,fiery,kindly,religious,charged,glowing
 kv	volt,v
-firefly	
 define	represent,distinguish,specify,outline,determine,establish,explain,detail,decide,characterize,interpret,sketch,prescribe,trace,mark,designate,describe,illustrate,limit,surround,set,bound,circle,trim
 judiciary	organization,bench,establishment,tribunal,brass,government,forum,authorities,regime,governance,organisation,administration,bar
-islander	
 maroon	scrap,quit,ditch,strand,abandon,isolate,leave,shed,desert,dump
 casper	wyoming
 hung	declined,floppy,hanging,falling,declining,descending
@@ -4705,7 +4447,6 @@ fair	peaceful,impartial,just,honest,fairness,gentle,objective,clear,unbiased,mod
 convinced	certain,accepting,sure,believing,secure,assured,positive,naive,confident,hopeful
 canonical	evangelical,episcopal,sacred,holy,ministerial,clerical,pastoral,orthodox,religious,divine
 lick	bust,wash,punch,slap,cream,box,rub,licking,shell,dab,crack,bop,bat,sock,bash,stroke,knock,slug,smash,beat,slam,knee,pick,pound,spank,plump,rap,chop,hand,bang,lam,clip,crush,kick,pounding,stripe,switch,cuff,hook,belt,hack,buffet,blow,hit
-filtration	
 yang	principle
 contributes	lead,advance,supply,support,provides,share,assist,commit,help,presents,strengthen,add,give,grant
 quebec	montreal
@@ -4732,8 +4473,6 @@ bizarre	unusual,wild,incredible,absurd,unreal,insane,strange,fantastic,odd,funny
 aggregator	collector,soul,somebody,mortal,someone,person,individual
 bounty	prize,gift,premium,bonus,reward,donation,price
 ancestors	folk,clan,group,tribe,fathers,house,people,household
-fo	
-israel	
 dramatic	comic,surprising,theatrical,sudden,tense,impressive,emotional,vivid,spectacular,exciting,powerful,wonderful,breathtaking,drama,tragic,striking
 arrives	comes,lands,appears,visit,report,enter,appear,reaches,land,reach
 neoplasms	tumors
@@ -4760,7 +4499,6 @@ scotch	defeat,cream,break,gut,sack,dynamite,destroy,end,whip,mar,wreck,smash,bea
 pupils	group,freshmen,students,readers,party,class,scholars
 doses	pills,remedies,drugs,pharmaceuticals,preparations,physics,caps,capsules,tablets,medications
 view	watch,see,analysis,vision,judgment,consideration,sentiment,feeling,notice,explore,prospect,command,scenery,sight,picture,impression,vanguard,outlook,opinion,regard,attitude,position,observe,way,aspect,forefront,light,perspective,notion,display,examine,landscape,concept,consider,orientation,judge,look,read,perceive,mind,scene,paradigm,thought,witness,vista,glimpse,panorama
-vega	
 modular	movable,standard,flexible,portable,removable,adjustable,mobile
 scheduling	arrange,recording,programming,registering,slate,filing,indexing,set,appoint,listing,compiling,entering,planning,booking,organize
 waterproof	tight
@@ -4773,7 +4511,6 @@ yell	cry,pipe,call,shout,scream,utter
 defines	represent,distinguish,specify,outlines,determine,circles,establish,explain,lines,detail,rounds,decide,characterize,interpret,prescribe,traces,designate,mark,describe,illustrate,limit,set,sketches,surrounds
 translation	crib,rendering,version,transcription,reading,adaptation,subtitle,caption,translating,summary,explanation,pony
 sunny	gay,happy,laughing,merry,pleasant,optimistic,radiant,shining,delighted,smiling,brilliant,satisfied,cheerful,bright,glowing
-tarot	
 furnace	heater,forge,boiler,register,stove,chamber
 carpets	curtains,blankets,sheets,coats,covers
 discontinued	ended,delayed,suspended,concluded,quit,finished,interrupted,canned,ceased,stopped,dropped
@@ -4813,7 +4550,6 @@ business	trading,firm,carrier,partnership,work,trade,marketplace,dealership,vent
 exposition	exhibition,show,interpretation,production,presentation,display,fair,exhibit,demonstration,expo
 salaries	wages,payroll,earnings,pay,payments,income,wage,fee,pays,hires
 files	edges,sands,planes
-thong	
 hotels	inns,campgrounds,motels,tavern,lodging,accommodations,hostels,house,resorts,hostel,motel,lodges,inn,resort
 marital	married
 singapore	asean
@@ -4825,16 +4561,12 @@ headlines	intelligence,headings,information,account,titles,report,word,headers,b
 origins	connection,influence,ancestry,sources,roots,beginnings,springs,genesis,fountains,lineage,motive,birth,wells,source,root,descent,fonts,ancestor,element
 dissemination	diffusion,transmission,dispersion,publication,extension,propagation,scattering,spreading,publishing,circulation
 needless	excessive,extra,pointless,optional,unnecessary
-pst	
-adp	
-scott	
 coaster	flagship,liner,collier,transport,boat,ship,corvette,resident,trader,packet,cutter,bark,vessel,yacht,cruiser
 appraisal	estimate,view,assessment,judgment,judgement,classification,evaluation,review,impression,pricing,opinion,assay,estimation,perception,rating,survey,check,sorting,belief,valuation
 agree	subscribe,comply,conform,allow,sign,conclude,admit,arrange,set,hold,recognize,collaborate,resolve,yield,acknowledge,cooperate,concord,settle,grant
 metals	timber,soul,stuff,making,matter,spirit,material,possibility,substance,potential,essence
 miniatures	models,reproductions,copies
 monte	cards
-dragon	
 complete	terminate,outright,thorough,determine,sweeping,end,perform,execute,fulfill,fulfil,entire,positive,conclude,halt,develop,do,action,polish,exhaustive,perfect,achieve,total,finish,accomplish,realize,full,close,settle,top
 cabinet	closet,locker,ministry,committee,dresser,government,chest,press,buffet,authority,shelf,administration,secretary,console
 linguistics	alphabet,syntax,semantics,science
@@ -4842,10 +4574,8 @@ verdict	sentence,decision,conclusion,award,answer,view,judgment,opinion,resoluti
 gardener	grower
 drawings	portraits,royalty,profit,cash,sketches,revenue,interest,earnings,wage,illustrations,pay,compensation,cartoons,proceeds,images,representations,figures,salary
 quartet	choir,ensemble,band,octet,group,combo,digit,orchestra,company,iv,four,cast,trio,duo,figure,chorus
-spectroscopy	
 transitions	transformations,passage,shifts,conversions,adjustments,alterations,conversion,modifications,transformation,development,growth,evolution,progress,shift,progression
 mayor	minister,politician,manager,representative,administrator,custodian,dean,director,official,executive,inspector,leader,officer,controller,authority,supervisor,secretary,commander,judge,agent,chief,organizer,commissioner,head,superintendent
-biochemistry	
 whipped	tanned,knocked,cut,beat,switched,hit,boxed
 automobiles	machines,cars,wheels,buses,suvs,autos,limousines,motors
 scare	excite,shake,panic,awe,stimulate,fear,stir,bluff,shock,dread,alarm
@@ -4856,7 +4586,6 @@ sensual	pleasing,lush,bodily,luxurious,delicious,pleasant,exciting,delightful,ph
 punishment	discipline,sentence,revenge,torture,correction,sanction,imprisonment,wrath,detention,beating,stick,medicine,abuse,music,penalty,suffering,trial,vengeance
 overlapping	coaxial,underlying,concurrent
 cranberry	bush
-algeria	
 eternity	everlasting,infinity,time
 colt	recruit,student,cub,punk,apprentice,novice,beginner,babe,freshman,male,newbie,rookie,virgin
 amps	lift,drive,trigger,fire,stir,inspire,activate,motivate,excite,cheer,stimulate,awake,brace,motive,spike
@@ -4869,13 +4598,10 @@ quarter	part,term,place,district,region,area,portion,precinct,sector,fourth,sect
 ringing	loud,piercing,sound,noisy
 remove	string,erase,take,clean,exclude,stone,clear,discharge,dig,eliminate,flick,shed,lift,strip,harvest,cast,shell,head,drop,bail,pull,tip,burr,separate,raise,stem,seed,spoon,ship,delete,empty,bur,hull,wash,transfer,gut,scoop,pick,draw,discard,dismiss,cream,brush,extract,throw,pit,transport,free,withdraw,cancel,bone,weed,scale,laden,hollow
 explosive	violent,acute,hard,ammunition,dynamite,powder,tense,mine,hazardous,missile,profound,bomb,furious,intense,ugly,fierce,fiery,heavy,intensive,unstable,terrible,volatile,deep,vicious,exquisite
-newcastle	
-diazepam	
 bare	uncovered,sheer,cold,exposed,uncover,empty,naked,very,arid,bald,stark,mere,expose,simple,vacant
 testimony	declaration,confirmation,evidence,demonstration,document,documentation,statement,data,affidavit,testament,information,witness,deposition,proof,validation
 opportunities	occasions,room,freedom,ways,moment,openings,excuse,time,shots,chances,event,hope,space,convenience
 alteration	adjustment,death,surprise,decrease,break,change,impairment,expiry,variation,modification,redesign,birth,amendment,increase,retardation,transition,deformation,play,mutation,sparkling,harm,acceleration,development,relief,variance,moderation,conversion,happening,slowing,remodeling,revision,revise,difference,transformation,separation,revolution,damage,shift
-shutter	
 gaps	void,rents,intervals,crack,cut,openings,disagreement,breaks,cracks,holes,hole,difference,divide,division
 speeds	favorites,preferences,pets
 fortunately	happily,luckily
@@ -4891,20 +4617,15 @@ sublime	abstract,surprising,divine,stunning,incredible,amazing,remarkable,superb
 documented	actual,accurate,archival,true,ancient,registered,dependable,definitive,literal,objective,classical,sustainable,reported,authentic,real,listed,established,factual,historical,documentary,reliable,scholarly,genuine,right
 vertices	tops,heights,heads,tips,peaks,flowers,sums,extremes
 gangs	bands,troops,companies,teams,parties,crews,outfits,armies
-overdrive	
 doubled	increased,duplicated,double,multiplied,enlarged,expanded
 cold	polar,arctic,freezing,cooled,temperature,raw,frozen,cool,distant,crisp,intense,snowy,bitter,cutting,chill,snow
 halls	entries
 differentiate	tell,contrast,vary,discriminate,alter,place,modify,distinguish,know,identify,adapt,difference,separate,transform,compare,label
-fifth	
 norfolk	virginia
 alt	el,altitude
-reproductive	
 standings	prestige,place,times,dates,spans,reputation,runs,terms,status,lives
 invariant	steady,even,uniform,fixed
-steroid	
 driven	automatic,spontaneous
-peter	
 wonderfully	amazingly,nicely,finely,beautifully,well,remarkably,great
 aria	solo,ballad,round,pop,psalm,jingle,noel,anthem,carol,standard,chorus,song,blues,opera,rocker,vocal,lyric,spiritual,hymn
 award	gold,assign,distinction,distribute,badge,decision,allocate,honor,trophy,presentation,citation,donate,premium,decoration,grant,present,scholarship,medal,endowment,addiction,verdict,prize,reward,gift,donation
@@ -4917,7 +4638,6 @@ native	inherent,domestic,indigenous,aboriginal,born,natural,local
 adam	xtc,ecstasy,x,go
 deficiency	drought,defect,flaw,shortage,failure,absence,poverty,weakness,lack,demand,need,fault,deficit,want,failing
 installs	receives,seats,accepts
-byron	
 furious	violent,intensive,savage,desperate,wild,raging,intense,mad,fierce
 notice	notification,find,review,order,view,poster,attention,recognize,sight,watch,acknowledge,advice,eye,sense,spot,care,instruction,directive,witness,memorandum,observe,news,perceive,criticism,spy,respect,comment,regard,remark,see,behold,catch,note,consideration,memo,manifesto,picture,advertisement,trace,distinguish,warning,story,discover,detect
 meadow	prairie,tract,plain,field,plot,pasture,lawn,ground,champaign,lea,savannah,clearing,grass,heath,green,savanna
@@ -4929,7 +4649,6 @@ ponds	pools,wells,basins,lakes
 sermons	lessons,advice,preaching,lecture,lesson,lectures,speeches,talks
 balcony	gallery,box,terrace,platform,structure,deck,porch,construction
 middle	norm,seat,eye,area,median,standard,center,mean,hub,midst,country,medium,centre,average,heart
-medina	
 idle	unused,latent,empty,lazy,free,unemployed,inactive,dead,ineffective,useless,vacant,off
 chairman	spokesman,leader,president,speaker,director,chair,administrator,moderator,chairperson
 technologies	applications,devices,automation,gadgets,inventions,tools,machines,machinery,mechanisms,instruments,apparatus,programs,innovations
@@ -4961,7 +4680,6 @@ dwelling	shelter,mansion,bungalow,condominium,den,housing,bath,cabin,homestead,c
 efficacy	effectiveness,adequacy,ability,efficiency,virtue,competence
 mesh	knit,combine,net,coordinate,web,in,trap,inch,fit,maze
 magical	charming,wizard,enchanted,fairy,charmed,weird,mysterious,supernatural,extraordinary,fascinating,cursed,unusual,wonderful,magic,marvelous,possessed
-nmr	
 bond	irons,confinement,security,imprisonment,bracelet,collar,fix,transaction,tie,certificate,obligation,chain,attraction,glue,bind,restriction,band,connect,restraint,relationship,trap,warrant,constraint
 chances	contingency,hazards,accidents,circumstances,luck,expectation,possibility,feasibility,chance,odds,prospect,anticipation,casualties
 whilst	while,when,as
@@ -4969,7 +4687,6 @@ overstock	abundance,overflow,surplus,excess,plus
 moroccan	morocco,african
 cooperate	concert,participate,collaborate,contribute,coordinate,assist,join,work,aid,combine,help,further,unite
 sovereignty	dominance,freedom,autonomy,jurisdiction,independence,liberation,liberty
-dental	
 trial	indictment,lawsuit,cross,run,testing,action,assay,examination,experiment,struggle,attempt,audition,effort,litigation,endeavor,preliminary,investigation,hearing,test,probation,tribunal,endeavour,fire,mot,case,contest,fitting,try,suit,prosecution
 slots	appointments,positions,jobs,places,functions
 ancestry	strain,extraction,origin,breeding,family,birth,blood,stock,genealogy,folk,descent,line,ancestor,sept,pedigree,side,lineage,heritage
@@ -4998,7 +4715,6 @@ hacking	playing,addressing,managing,swinging,fielding,treating,handling,taking,n
 wisconsin	usa,superior,us,madison,midwest,watertown,milwaukee,appleton,america
 algorithm	agenda,software,step,scheme,action,practice,proceeding,strategy,form,conduct,rule,operation,plan,transaction,move,policy,program,formula,method,measure,application
 believing	convinced,naive,certain,secure,hopeful,sure,confident,accepting
-anabolic	
 prestige	position,importance,reputation,distinction,power,magnitude,celebrity,dignity,import,consequence,significance,rank,weight,esteem,value,standing,status,moment,fame
 link	string,couple,channel,contact,mean,hook,remember,unite,attach,compound,interconnect,think,relate,tie,chain,identify,join,element,integrate,bind,network,hitch,connect,relationship,associate,association,combine
 reinforcement	mount,pillar,shore,bracket,arch,support,mounting,spur,stay,foundation,column,prop,brace,operation
@@ -5007,7 +4723,6 @@ supplemental	peripheral,auxiliary,additional,added,secondary,complementary,acces
 workload	job,duty,game,employment,task,occupation,profession,load,work,function
 innocence	integrity,goodness,purity
 trivial	minor,minute,foolish,little,petty,meaningless,slight,superficial,incidental,irrelevant,small,negligible
-bronx	
 crime	scandal,mayhem,attack,offence,offense,breach,evil,violation,case,felony,misconduct,corruption,fraud,attempt,commission,infringement
 describes	paints,represents,sketches,term,report,call,summarizes,represent,illustrate,renders,detail,shows,chronicle,tells,draws,outlines,name,defines,outline,relates,illustrates,label,characterize,tell,define,suggests,pictures,express,interpret,demonstrates,specify
 testify	argue,swear,verify,indicate,witness,assert,announce,declare
@@ -5015,7 +4730,6 @@ skirt	bound,garment,seat,rim,perimeter,hem,edge,fringe,bypass,dodge,frame,ignore
 terrace	gallery,patio,garden,balcony,platform,roof,deck,porch,area
 association	relation,club,order,federation,institute,consortium,interaction,alliance,organization,guild,connection,society,dealings,solidarity,family,partnership,tribe,collaboration,liaison,cooperative,merger,league,organisation,corporation,lodge,chapter,affiliation,asean,pack,syndicate,cooperation,company,fellowship,conference,union,gang,relationship,associate,ring,pool,legion,mob
 avatars	icons,images,souls,abstracts,models
-trent	
 nominate	term,recommend,call,nickname,appoint,assign,designate,tap,name,propose,title,label,style,decide,submit,rename,suggest,present,elect,dub,draft,choose,specify
 cuban	cuba
 piper	performer,pianist,guitarist,artist,drummer,maestro,musician
@@ -5023,7 +4737,6 @@ disadvantaged	poor,deprived,impaired,depressed,needy
 surveyed	checked,noticed,detected,attended,interviewed,realized,recognized
 ham	surprising,theatrical,emotional,spectacular,exciting,wonderful,awesome,affected,amazing,marvelous
 deputy	spokesman,ambassador,minister,spokesperson,proxy,factor,aide,attorney,commissioner,agent,manager,delegate,representative,rep
-barefoot	
 pay	wage,profit,finance,allowance,repair,remuneration,income,redeem,charge,contribute,repay,return,drop,prefer,offer,give,extend,serve,corrupt,meet,pick,salary,refund,payment,grant,present,compensation,reimbursement,buy,handle,compensate,benefit,reward,foot,fee,produce,settle,spend
 thanksgiving	appreciation,nov,november,thanks,gratitude
 paint	decorate,color,represent,oil,illustrate,charge,stain,enamel,image,dye,cosmetic,pigment,outline,acrylic,create,characterize,render,define,wash,latex,describe,design,draw,brush,picture,shade,makeup,coat,cover,sketch,watercolor,wax
@@ -5079,7 +4792,6 @@ instances	precedent,reason,example,occurrence,detail,indications,particular,spec
 collaborative	public,combined,mutual,cooperative,reciprocal,joint,shared,united,communal,collective,multiple
 payload	loading,merchandise,product,cargo,draft,burden,haul,ware,weight,freight,load,shipment
 fluffy	light,creamy,tender,ethereal,silky,soft,lightweight,delicate
-mats	
 salary	earnings,wage,compensation,payroll,overtime,found,remuneration,hire,income,pay,payment,fee
 drift	travel,slip,progression,slide,cruise,tendency,coast,stroll,fly,dance,ride,race,breeze,sail,blow,stream,roll,wash,sweep,wander,brush,speed,tide,rush,stray,flow,glide,go,float
 relationships	relation,communication,partnerships,contact,mergers,dealings,liaison,connections,tie,unions,relations,affair,exchange,interactions,alliances,link,associations,collaborations,affiliations,accord,marriage
@@ -5103,7 +4815,6 @@ thin	light,poor,transparent,decrease,angular,shallow,depressed,sparse,thick,thic
 mob	crowd,mass,crush,clan,press,horde,riot,herd,masses,multitude,army,drove,troop,gang,bike,legion,host,flock
 bogus	artificial,imitation,pretend,false,forged,faux,fraudulent,dummy,simulated,synthetic,substitute,manufactured,process,designer,fake,mock
 elsewhere	abroad,outside,aside,away,somewhere,hence,out,down,apart,off
-granada	
 browning	preparation,cooking
 friends	brethren,brothers,mates,associates,partners,colleagues,peers,sisters,companions,pals,buddies
 wonderland	utopia,sion,earth,eden,heaven,ground,land,zion,bliss,nirvana,paradise
@@ -5119,7 +4830,6 @@ currently	today,nowadays,here,directly,presently,anymore,now
 contain	collect,have,comprise,incorporate,hold,accommodate,stop,cool,house,involve,bear,curb
 rods	bats,clubs
 regarding	careful,thinking,alert,responsible,cautious
-budapest	
 fled	flew,melted,faded,disappeared,dissolved
 wires	ropes,sale,lines,trade,commerce,cords,strings,business,cables
 suburbs	towns,cities,municipalities
@@ -5142,7 +4852,6 @@ landfill	dump,depot,tip
 chennai	india
 purses	bags,handbags,wallets
 corridors	hall,lobby,zones,territories,lands,parts,belts,aisle,regions,districts,passage
-sigma	
 worker	somebody,staff,stripper,poster,hanger,independent,soul,volunteer,mortal,helper,temporary,help,servant,person,washer,tier,collector,temp,processor,assistant,employee,slave,individual,driver,carter,freelance,supporter,splitter,seasonal,rat,someone
 involving	entertaining,exciting,engaging,fascinating,interesting,consuming,inspiring,intriguing,amazing,absorbing,amusing
 transient	little,passing,flash,short,traveler,temporary,brief
@@ -5157,7 +4866,6 @@ imported	introduced,external,exotic,multicultural,multilateral,multinational,ali
 advertise	endorse,broadcast,tout,publish,sponsor,herald,disclose,release,reveal,denote,promote,declare,post,display,communicate,announce,exhibit,headline
 stands	lies,sits,is,remains
 closeouts	bargains,bonuses,deals,premiums,gifts,buys,presents,steals,freebies
-router	
 limiting	restrictive,restricting,actual,definite,exclusive,steep,selective,ultimate,reliable,precise,specific,exhaustive,excessive,decisive,definitive,lethal,fatal,blocking
 warrior	somebody,brave,samurai,knight,someone,veteran,hero,soldier,champion,raider,irregular,individual,ranger,person,fighter,marine,soul
 jew	somebody,mortal,hebrew,individual,person,soul
@@ -5171,7 +4879,6 @@ excessive	unreasonable,steep,stiff,extreme,extra,endless,inappropriate,enormous,
 wishing	forcing,imposing,want,desire
 funeral	burial,ceremony
 incorporate	blend,fuse,compound,merge,mix,absorb,cover,organize,combine,integrate,consolidate
-b	
 showdown	duel,warfare,dispute,contention,match,clash,friction,sweepstakes,row,argument,confrontation,disagreement,struggle,controversy,conflict,encounter,crisis,combat,collision,battle,contest,war,debate,competition
 reaches	passes,hands,transfers,carries,gives
 logs	records,notes,registers,enters,reports,marks
@@ -5204,8 +4911,6 @@ desires	appeal,hunger,cries,demands,passion,lust,ambition,appetite,need,applicat
 towel	erase,tissue,drain,clean,remove,dust,bake,empty,rub,wash,mop,exhaust,dry,wipe
 addition	supplement,wing,additive,bonus,boost,enhancement,inclusion,annex,component,extension,expansion,element,constituent
 barbecue	buffet,carnival,festival,gala,blowout,picnic,grill,luncheon,roast,dinner,fry
-myrtle	
-handel	
 demanded	accessible,desired,public,required,compulsory,immediate,forced,pressing,appropriate,serious,familiar,requisite,vital,urgent,essential,imposed,imperative,needed,prevalent,ubiquitous,critical,mandatory,prescribed,important,indispensable,necessary,enforced,universal,recommended,compelling,demanding,crucial,incumbent
 ledger	cost,journal,record,bill,book,receipt,invoice,rate,statement,accounting,fee,expense,account,document,tab
 pursued	tailed,watched,ran,tracked,run,tagged,sought,followed,traced,accompanied
@@ -5223,7 +4928,6 @@ bonded	bound,tight,embedded,set,lodged,firm,stuck,frozen,impacted,secured,attach
 reliance	pillar,backbone,trust,standby,dependence,anchor
 striving	endeavour,strain,effort,pass,undertaking,endeavor,offer,bid,essay,try,struggle,assay,go,attempt,pains,trial
 demolition	loss,finish,explosion,conclusion,ruin,extinction,destruction,rack,ending,havoc
-leu	
 numbering	computing,total,calculation,telling,counting,checking,calculating,listing,toll,result,poll,list
 real	positive,actual,legitimate,sincere,true,identifiable,substantive,very,objective,reality,certain,honest,authentic,physical,legal,original,realistic,substantial,historical,right,solid,documentary,realism,certified,concrete,genuine,pure,evident,absolute
 pipeline	conduit,pipe,agenda,lineup,duct,table,channel,diary,chronology,journal,route,cylinder,information,vent,sewer,source,list,supplier,vessel,gossip,card,almanac,tunnel,docket,avenue,outlet,program,intelligence,timetable,line,hose,conversation
@@ -5232,7 +4936,6 @@ melting	dissolution,melt,departure,retirement,withdrawal,going,passing,departing
 pig	sus,hog,pork
 internationally	foreign,transnational,multinational
 halloween	day
-anguilla	
 overcoming	healthy,successful,stunning,happy,licking,amazing,succeeding,beating,devastating,mastering,encouraging,profitable,vast,taking,helpful,wealthy,lucky,stopping,finishing,getting
 destruction	elimination,loss,holocaust,kill,liquidation,massacre,ruin,conclusion,murder,slaughter,collapse,extinction,termination,demolition,disaster,ending,havoc
 believes	take,have,hold,buys,trusts,admit,think,feel,expect,regard,suppose,suspect,takes,conclude,understand,accept,consider,understands,assumes,accepts,maintain,trust,credits
@@ -5311,7 +5014,6 @@ occupied	populated,filled,working,engaged,active,employed,busy,settled
 impedance	handicap,conflict,dispute,resistance,refusal,barrier,hitch,battle,support,fight,hassle,trouble,hatred,struggle,interruption,obstacle,protection,interference
 processor	business
 tones	manners,fashions,styles,modes,veins
-arp	
 advising	counseling,telling,warning,teaching,coaching,urging,convincing,encouraging,guiding,informing,counselling
 ecology	preservation,biology,conservation
 tomcat	kit,tom,cat,kitty,pussycat,kitten
@@ -5336,8 +5038,6 @@ glazing	dressing,shining,finishing,grinding,polishing,coating,rubbing
 shock	slap,knock,crash,contact,rock,earthquake,strike,insult,impact,kick,confusion,blow,shake,slam,trauma,pounding,encounter,bump,disturbance,anger,awe,collision,collapse,punch,excitement,injury,scare,jar
 burial	funeral
 delegates	missionaries,meeting,agents,representatives,show,ministers
-caribbean	
-racist	
 lithium	metal
 baby	small,kid,little,toddler,infant,girl,babe,miniature,newborn,chick,child,mini,boy
 portion	relation,residue,rest,particular,substance,accident,fraction,remainder,excerpt,base,circumstance,chance,basis,detail,constituent,fate,destiny,section,subpart,member,chunk,quantity,part,balance,residual,fortune,serving,lot,doom,component,segment,item,hazard,piece,allocation,fragment,unit
@@ -5357,7 +5057,6 @@ silhouette	shade,shape,figure,contour,shadow,outline,portrait
 fancy	deluxe,imagination,detailed,elegant,complicated,magnificent,decorative,fantasy,image,realize,imagine,realise,figure,see,understand,special,elaborate,project,picture,involved,sophisticated,complex,exquisite
 currents	winds,tides,directions,trends,runs,shifts
 telegraph	cable,predict,call,forecast,communicate,coil,anticipate,think,relay,air,determine,announce,transmit,calculate,gauge,thread,imply,beam,conclude,post,strand,write,airmail,line,correspond,mail,apparatus,send,estimate
-wilson	
 conventional	customary,common,ordinary,typical,convention,prevailing,going,regular,standard,formal,prevalent,current,usual,average,normal,traditional,popular
 detroit	mi,michigan
 compete	touch,challenge,rival,battle,run,race,vie,fight,match,face,contest,clash,equal,try,play
@@ -5448,7 +5147,6 @@ tunnels	mine,mines,caves,galleries,shaft,pit,holes,pits,subway,hole,wells,channe
 potter	play,idle,lounge,fool,craftsman,artisan,interfere
 different	another,mixed,assorted,varied,other,separate,strange,polar,variant,distant,unusual,varying,incompatible,rare,peculiar,distinct,unique,unlike,special,distinctive,bizarre,various,opposite,extraordinary,several,difference,divers,diverse
 international	universal,planetary,global,world,transnational,worldwide,multinational,foreign
-unisex	
 corner	box,difficulty,country,swamp,jackpot,crisis,fix,spot,bind,hole,edge,jam,angle,intersection,rim,dilemma
 buds	adolescents,teens,monkeys,youths,chicks,cubs,babies,children,teenagers,kids
 covers	lid,bury,umbrella,reach,mask,cap,coat,shelter,envelope,roof,sheet,jacket,examine,blanket,tent,substitutes,comprise,spells,dress,subs,front,screen,involve,protect,canvas,top
@@ -5493,11 +5191,9 @@ rates	tax,grades,taxation,qualities,standards,classes
 intercontinental	continental,international,universal,foreign,transnational,multinational,multicultural,global
 celebrations	festival,birthday,party,triumph,bash,anniversary,festivals,jubilee,gala,performance,ceremony
 doing	act,action,thing,experience,achievement,work,exploit,accomplishment,undertaking,activity,feat,performance,deed
-gourmet	
 optic	iris,lens,od,face,receptor,lid,aperture,optical,orb,visual,os,eye
 reception	greeting,gathering,bash,response,function,buffet,blast,blowout,supper,dinner,reaction,affair,occasion,party,receiving,formal,welcome,event,dance,gala,celebration,meeting,ball,encounter
 where	wherever
-waterloo	
 illustrations	diagrams,portraits,plates,drawings,figures,graphics,artwork,pictures
 implementing	executing,enforcing,administering,manufacturing,applying,construction
 nozzle	nose,faucet
@@ -5505,32 +5201,24 @@ iris	pupil,optic,eye
 couch	chair,sofa,seat,chesterfield,convertible,lounge,bed
 speculation	hypothesis,adventure,possibility,belief,enterprise,chance,flyer,throw,gamble,opinion,bet,venture,thought
 blunt	straightforward,short,honest,bluff,explicit,candid,direct,rough,sap,rude,plain,frank,undermine
-pitt	
 entrepreneurial	purchaser,buyer,seller,trader,dealer,retailer,businessman,vendor,merchant
 intrinsic	native,constitutional,inner,underlying,elemental,indigenous,fundamental,integral,distinctive,intimate,peculiar,natural,inherent,essential,internal,inherited
-sars	
 calculus	calculation,estimation,numbers,rock,algebra,mathematics,figures,math,geometry,computation,arithmetic,stone
-joyce	
-mph	
 continuing	perpetual,continued,running,chronic,enduring,constant,continual,lasting,continuous
 subpart	constituent,part,component
 sing	hum,wait,hymn,carol,render,whistle,troll,interpret,shout
-capitalism	
 dirt	gravel,mud,ground,stain,clay,earth,sand,dust,mold,soil,till
 guarantees	prove,contract,secure,protect,agreement,insists,insure,collateral,certificate,deposit,contracts,assurance,security,support,insurance,vows,bonds,maintain,assure,warrants,warranty,ensure
 congenital	native,constitutional,chronic,proper,natural,born,regular
 rented	leased
 validity	might,substance,credibility,authority,weight,influence,punch,legitimacy,strength,effectiveness,power,gravity,efficacy,impact
-gutenberg	
 bought	commercial,store
 enjoy	admire,fancy,dig,have,prefer,retain,hold,love,experience,appreciate,use,own,maintain,like
 rope	cable,lace,tape,strand,line,cord,thread,wire,brace,string,tier
 outcomes	results,fruits,conclusions,products,developments,reaction,event,effects,issue,sequences,conclusion,implications,consequences,result,children,issues
 privileges	freedom,authority,honors,concessions,concession,benefit,authorization,entitlement,allowance,license,right,immunity,exemption,advantage,opportunity,rights
-ke	
 satellite	advocate,soldier,spacecraft,convert,equipment,supporter,partisan,faithful,pupil,apostle,fan,champion,student,missionary
 nutritional	nutrient,dietary
-lasik	
 attain	secure,get,promote,score,complete,realize,make,accomplish,achieve,hit,average,manage,reach,begin,compass,acquire,obtain,garner,strike,earn,reap,win,succeed,gain
 download	load
 pulse	heartbeat,pounding,vibration,beating,beat
@@ -5586,14 +5274,12 @@ bi	metal
 builders	artists,architect,producer,contractor,manufacturers,architects,artisan,mechanics,manufacturer,makers,inventor,maker
 treat	cover,address,wrong,nurse,handle,deal,manage,step,baby,use,disregard,hold,gift,interpret,regard,cure,approach,heal,conduct,cut,mock,delight,operate,administer,thrill,think,abuse,sweet,evaluate,dress,take,ignore,pleasure,fun,provide,feast,play,advise,interact,employ,respect,give,consider,serve,study,prescribe
 compared	associated,referred,linked,connected,related
-augustine	
 stay	stop,holiday,pause,dwell,hold,abide,stand,hang,settle,be,keep,delay,suspend,continue,wait,last,reside,vacation,suspension,rest,live,remain,arrest
 travelled	traveled,carry,fly,trek,visit,go,move,migrate,proceed,tour,wander,sail,cross,crowded,cruise,vacation,walk,drive,transmit,busy
 healing	therapeutic,rehab,recovery,comeback,remedial,rehabilitation
 partnerships	company,firm,association,relations,union,cooperation,connections,affiliations,corporation,organization,relationships,mergers,interactions,alliances,cooperative,collaborations,sharing,associations,dealings,ownership,society,business,friendship,interest,assistance,unions
 justify	support,sustain,confirm,advocate,excuse,validate,warrant,explain,defend,ignore,maintain,favor
 military	naval,army,martial,service,troop,force,navy
-stationery	
 definition	rendering,answer,description,rationale,picture,solution,sketch,translation,portrait,explanation,interpretation,tale
 neutral	sovereign,inactive,impartial,unbiased,independent,autonomous
 carried	transferred,packed,took,delivered,transported,sent,shipped,bore,brought
@@ -5612,7 +5298,6 @@ joke	wit,josh,humour,sally,crack,gag,laugh,parody,trick,funny,riot,rib,wow,humor
 worst	lowest,lower,poor,terrible,routine,ubiquitous,frequent,lesser,inferior,everyday,bad,usual,ill,deficient,unacceptable,ordinary,bush,common,garden,familiar,bottom,last,wanting,off,normal,lame,household,depressed,worse
 coverage	scope,content,sum,insurance,analysis,report,amount
 goal	end,meaning,plan,desire,destination,purpose,intent,dream,ambition,aim,idea,point,intention,content,ideal,design,thing,target,objective,object
-spinal	
 norway	oslo,svalbard,nato,bergen,norwegian,scandinavia
 endpoint	termination,end
 underwood	forest,woods,wood,brush,scrub
@@ -5633,7 +5318,6 @@ assist	reinforce,attend,lift,avail,care,encouragement,ease,backing,back,support,
 land	territory,region,terrain,dock,win,shore,country,ranch,realty,acreage,nation,republic,continent,estate,kingdom,settle,earth,tract,state,beach,homestead,area,home,commonwealth,province,parcel,field,have,sovereignty,get,homeland,plot,soil,empire,secure,district,ground,countryside
 stepped	skip,dance,walk,tread,incremental,gradual,progressive
 greenwich	london
-arthur	
 puppies	dogs,hunters
 wrapper	house,shield,plate,coating,envelope,backing,package,facing,bark,skin,crust,hide,mail
 theses	theories,assumptions,arguments,proposals,hypotheses
@@ -5648,7 +5332,6 @@ females	ladies,girl,mother,women
 ensemble	costume,cast,rig,gear,orchestra,garments,suit,wardrobe,threads,apparel,trio,outfit,band,wear,dress,couture,chorus,choir,quartet,clothing
 surplus	extra,unwanted,unnecessary,redundant,spare,unused,excess,additional
 regional	provincial,territorial,local
-paraguay	
 fertilizer	organic,dressing,compost,chemical,manure
 crossed	different,varied,grade,scratch,cross,hybrid,blended,diverse
 arizona	flagstaff,us,az,mesa,prescott,southwest,tucson,america,phoenix,colorado,usa
@@ -5662,7 +5345,6 @@ urgent	dangerous,serious,immediate,essential,crying,crucial,critical,dire,vital,
 provision	arrangement,limitation,terms,condition,qualification,plan,requirement,restriction,exception,modification,reservation,contingency
 fibers	threads,wires
 strongest	robust,mighty,tough,main,sturdy,powerful,leading,muscular,hard,paramount,athletic,outstanding,prominent,key,major,potent,dominant,energetic,stout,rugged,vigorous,healthy,prime,primary
-abs	
 antarctica	antarctic
 officer	chief,man,inspector,leader,aide,representative,sergeant,detective,police,captain,cop,sheriff,copper,investigator,manager,deputy,director,executive,official,agent
 explosion	fragmentation,burst,blast,discharge,inflation,outbreak,firing
@@ -5706,7 +5388,6 @@ precipitation	fall,hustle,speed,rush,rainfall,snow,storm,velocity,rain,hurry
 stared	watched,look,beam,peer
 xii	cardinal,dozen
 distinguishing	peculiar,individual,typical,characteristic,diagnostic,classic,proper,distinctive,identifying,distinct
-apis	
 skies	highs,horizons,blues,heavens
 occasionally	hardly,seldom,periodically,now,sometimes
 mapquest	explore,search
@@ -5724,7 +5405,6 @@ brandy	beer,whisky,spirits,mum,sake,rum,vodka,wine,mead,ale,brew,gin,marc,whiske
 matter	material,motive,topic,issue,circumstance,subject,question,consequence,purpose,imply,essence,situation,argument,concern,importance,count,incident,idea,affair,problem,element,least,job,proceeding,point,theme,involve,affect,mean,transaction,event,content,sense,thing,consideration,business,motif,interest
 wounded	liable,damaged,hurt,disabled,injured,impaired,vulnerable
 plump	thick,full,chubby,round,gross,husky,stout,fat,heavy,soft,ripe,overweight,obese
-nasa	
 skeletal	lean,hungry,thin
 cosmetics	makeup,paint,lipstick
 elephant	blockbuster,titan,jumbo,dinosaur,trunk,monster,whale,giant,mammoth,hulk
@@ -5755,7 +5435,6 @@ indicator	signal,needle,gage,gauge,bmi,fact,index,symbol,pointer,hand
 hacked	pulled,fierce,distressed,concerned,manipulated,afraid,restless,managed,weary,raging,took,treated,negotiated,violent,played,careful,addressed,desperate,nervous,scared,handled
 mice	sheep,insect,mosquito,ant,pussies,flea
 politician	mayor,senator,leader,representative,governor,president
-bailey	
 escape	emerge,depart,exit,run,fly,flee,leave,liberation,flight,go,breakout,dodge,move,disappear,slip,withdrawal,outbreak,departure,rescue,freedom,shake,avoid,break,lose
 preferred	desirable,approved,favorite,select,favored,elect,chosen,choice,picked,selected
 qualification	talent,stuff,fitness,goods,provision,competence,accomplishment,eligibility,expertise,capacity,gift,suitability,mastery,experience,quality,ability,condition,competency,facility,making,adequacy,credentials,proficiency,skill,criterion,capability
@@ -5831,14 +5510,12 @@ prosperity	growth,wealth,expansion,abundance,health,capital,boom,inflation,welfa
 aging	ageing,elderly,retired,older,old,senior,aged,adult,ancient
 digits	integers,numbers,figures
 remarkable	peculiar,wacky,bizarre,curious,abnormal,uncommon,striking,exceptional,impressive,solid,weird,significant,surprising,strange,wild,outstanding,crazy,noteworthy,notable,fantastic,unusual,outrageous,wonderful,funky,odd,funny,important,singular,unique,noticeable,queer,rare,extraordinary
-olympia	
 decent	moral,comfortable,thoughtful,honorable,respected,honest,fair,ethical,straight,good,adequate,right,worthy,modest,noble,just,polite,correct,prudent,reasonable,acceptable,righteous,nice,proper,true,satisfactory,upright,competent
 evenings	nights
 lu	metal
 personalities	makeup,lights,nature,identity,celebs,temper,self,names,stars,icons,charm,heroes,celebrities,figures
 remembered	recalled,reproduced,minded,reminded
 lasting	stable,endless,timeless,perennial,everlasting,lifelong,constant,immortal,standing,perpetual,eternal,enduring,ongoing,durable,continuing,permanent
-queens	
 west	europe,western
 emerald	green
 parcels	packages,equipment,mixtures,suites,varieties,arrays,bands,series,clusters,batteries,blocks,gear,groups,sets,lots,luggage,collections,banks
@@ -5847,12 +5524,10 @@ announcing	transmission,flashing,link,coverage,conversation,attention,commercial
 abdominal	tummy,gut,oblique,ab,intestinal,waist,stomach,belly
 executed	applied,implemented,administered,enforced
 meant	indicated,latent,contracted,candid,suggested,serious,expected,hidden,genuine,earnest,explained,designed,real,promised,denoted,imported,represented,intended,doomed,calculated,voluntary,implied,coming,expressed,indirect,true,planned,proposed,spelled,implicit
-vanessa	
 vans	pioneers
 desktop	screen
 announcement	message,release,ad,notification,briefing,brochure,declaration,broadcast,advertisement,report,revelation,news,advert,posting,advertising,publication,statement,notice,prediction,bulletin,disclosure
 buyer	browser,customer,patron,correspondent,purchaser,client,prospect,shopper,guest,user,consumer
-bh	
 director	principal,manager,organizer,superintendent,chief,commissioner,president,leader,executive,supervisor,administrator,head,player,exec,producer
 magazines	brochure,manual,periodical,warehouses,daily,booklet,journal,newspaper,newsletter,containers,weekly,paper
 jasmine	bush
@@ -5892,7 +5567,6 @@ specimen	human,devil,cookie,duck,life,man,guy,bod,copy,representative,face,baby,
 dwellings	houses,rooms,cabins,residences,cottages,quarters,homes,apartments,places
 businesses	market,store,companies,deal,issue,firm,houses,factory,shop,institution,employment,partnership,venture,trading,work,corporation,organization,firms,establishments,agencies,problem,enterprises,interest,industry,field,corporations,transaction,house,associations,manufacturing,concerns,trade,interests
 divorced	separated,sole,isolated,disconnected,sovereign,distant,free,distinct,detached,removed,single,independent
-sixth	
 contracted	compact,limited,narrow,thick,pledged,guilty,matched,decreased,sturdy,engaged,exhausted,stiff,petty,slim,diminished,drained,subject,thin,solid,wooden,expected,fast,constrained,tight,small,reserved,tense,strong,obliged,hooked,designed,compressed,stable,isolated,precise,promised,condensed,definite,slender,compelled,rigid,obligated,calculated,close,committed,liable,linear,planned,proposed,stark,steady
 honour	thank,celebrate,fame,esteem,praise,recognize,acknowledge,glory,respect,standing,compliment,regard,reputation,celebrity,honor,salute
 retailer	trader,merchant,operator,exporter,chandler,seller,distributor,broker,entrepreneur,banker,licensee,clerk,vendor,wholesaler,dealer,agent,reseller
@@ -5924,14 +5598,11 @@ rational	analytical,deliberate,thoughtful,mental,sane,impartial,sober,analytic,i
 c	degree
 tens	dolls,hunks,dishes,babes,fox,studs
 ds	element
-castles	
 trails	paths,pathways,roads,streets,traces,routes,tracks
 defects	flaw,damages,shortage,depart,reject,quit,spots,error,weaknesses,abnormalities,weakness,flaws,scars,faults,bug,crack,desert,mistake,abandon,deficiency,lack,fault,revolt,bugs,withdraw,marks,stains,injuries,injury
-owe	
 knob	projection,chunk,lump,lever,piece,patch,bit,latch,boss,hunk,bead
 best	terrific,foremost,smart,perfect,finest,choice,formal,leading,sunday,beat,overcome,favorite,outstanding,neat,premier,blank,chic,elegant,optimal,conquer,fashionable,superior,greatest,tidy,optimum,prime,top,stylish,trim,first
 picnic	relaxation,outing,utopia,holiday,vacation,rest,paradise,excursion,heaven,barbecue,ease
-garlic	
 offered	extended,performed,gave,voluntary,implied,staged,posed,recommended,advised,proposed,acted,spontaneous,submitted
 bureau	ds,division,authority,ai,nist,army,gpo,phs,committee,commission,office,service,department,usa,agency,faa,osha,branch,organ,nsw,navy,gao,fha,ins,nih,fda,desk,irs,board,cdc
 pardon	forgiveness,excuse,allowance,immunity,discharge,parole,tolerate,amnesty,forgive,mercy
@@ -5947,7 +5618,6 @@ funny	witty,screaming,hilarious,playful,entertaining,humorous,unusual,weird,absu
 retire	resign,sleep,retreat,remove,bed,separate,withdraw,nod,depart,bunk,crash,nap,quit,go,settle,surrender
 coefficients	measures,degrees,volumes,quantities,amounts,numbers,portions,many
 petroleum	gasoline,carbon,crude,fuel,oil,petrol,gas,c
-atlantis	
 implications	suggestions,stuff,indication,indications,questions,significance,meaning,matters,cues,topics,messages,conclusion,hints,senses,clues
 headline	banner,caption,header,heading,title,subtitle,newspaper,head,paper
 confidence	certainty,determination,trust,unsure,sure,vanity,pride,authority,courage,hope,spirit,faith,ego,morale,assurance,uncertain
@@ -5958,7 +5628,6 @@ animations	brightness,cheer,sparkle,vitality,spirit,enthusiasm
 honours	degree
 primarily	mainly,originally,initially
 lower	sink,cut,fall,junior,less,dip,drop,decrease,slash,minor,subordinate,lesser,inferior,small,reef,reduce,smaller,move
-amelia	
 veil	cover,shield,covering,wraps,hood,blanket,curtain,mantle,cope,mask,robe
 percentile	mark,score
 submission	compliance,content,resignation,filing,substance,entry,obedience,conformity,surrender
@@ -5976,7 +5645,6 @@ mentioned	implied,suggested,published,indicated,noted,noticed,named,announced,qu
 happiness	laughter,delight,prosperity,bliss,satisfaction,ecstasy,spirit,unhappy,pleasure,enjoyment,optimism,joy
 rendered	concentrated,performed,clean,refined,tried,pure,filtered,strong,plain,clarified,fresh,purified,executed
 coordination	teamwork,arrangement,fairness,engineering,rule,system,settlement,collaboration,adjustment,grade,distribution,cooperation,direction,institution,location,analysis,tolerance,regulation,partnership,organization,timing,strategy,identity,community,scheme,grouping,allocation,control,governance,planning,supervision,designation,parity,management,structure
-sugar	
 postcards	cards,reports,mails,letters,communications
 trapped	arrested,bound,captured,occupied,caught,confined,captive
 efficiently	strongly,surely,conveniently,completely,nicely,easy,very,effectively,regularly,accurately,closely,correctly,lightly,fully,readily,smoothly,quickly,successfully,highly,comfortably,easily,freely,thoroughly,wholly,carefully,extremely,precisely,well,naturally,properly,simply,adequately
@@ -6012,7 +5680,6 @@ good	desirable,perfect,smashing,informed,legitimate,appropriate,marvelous,positi
 hospice	campground,hostel,shelter,inn,lodge,motel,ward,hotel,tavern,clinic
 tec	investigator,detective,officer
 grace	elegance,kindness,style,privilege,compassion,waiver,goodness,refinement,dignity,generosity,service,mercy,agility,beauty,courtesy,benefit,love,advantage,turn,favor,decorate,indulgence,ease,blessing
-cayman	
 stainless	clean,sparkling,pristine,bright,shiny,pure,white,sterile,snowy,sanitary
 postcode	zip,address,destination
 logger	jack,sawyer
@@ -6041,14 +5708,12 @@ fields	grounds,parcels,plots,green,lots,commons,meadows
 refusing	veto,weak,adverse,declining,withholding,rejection,denying
 savannah	lea,meadow,champaign,georgia,prairie,plain,field,heath
 varies	modify,differs,differ,range,alter,divide
-wto	
 transformed	updated,converted,altered,cooked,adjusted,modified,corrected,replaced
 bearing	significance,supporting,connection,relevance,applicability,importance,manner
 entertainment	production,performance,nightlife,amusement,show,recreation,enjoyment,diversion
 classics	prose,essay,history,leaflet,examples,standards,mirrors,brochure,information,novel,poetry,drama,models,ideals,composition,story,lore,ideas,biography,research,article
 newsletter	edition,gazette,newspaper,rag,review,magazine,book,report,account,quarterly,daily,serial,zine,journal,mag,organ,weekly,yearbook,story,periodical,monthly,annual,bulletin,paper
 aroma	spice,scent,balm,odor,fragrance,incense,smell,property,perfume,bouquet
-ssa	
 cosponsors	teachers,advocates,supporters,patrons,champions,sponsors
 ivy	vine
 alternate	mix,insert,weave,cyclic,rotate,incorporate,thread,combine,blend,alter,salt,vary
@@ -6094,7 +5759,6 @@ comparable	corresponding,parallel,like,akin,similar,matching,identical,analogous
 inserting	enter,weaving,introducing,introduce,implant,adding,installing,include,stick
 often	generally,constantly,commonly,consistently,continually,hourly,again,always,repeatedly,frequently,continuously,usually,much,regularly
 these	near,closer,front
-ans	
 year	hour,moment,past,pace,life,segment,stretch,stage,duration,quantity,dimension,age,height,present,day,piece,limit,mileage,future,range,radius,second,era,while,week,decade,month,annum,point,occasion,turn,space,generation,breadth,cycle,span,diameter,epoch,portion,period,term,time,section,yr,width,season,magnitude,date
 plans	strategies,games,proposals,engineering,plan,designs,systems,arrangements,recipes,schemes,procedures,slate,strategy,coordination,schedule,curriculum,agenda,bill,programs,record,calendar,planning,ideas,intentions,projects,ways,business
 movable	mobile,portable,removable,flexible,moving,adjustable,modular
@@ -6124,7 +5788,6 @@ hiring	contracting,enrollment,engaging,leasing,renting,job,business,service,recr
 loans	advances
 ninety	xc,cardinal
 elevation	altitude,ascension,advancement,rise,rising,lift,upgrade,upgrading,preference,promotion,creation,mountain
-moss	
 struts	steps,pads
 alas	aw,rats,ow,boo,unfortunately,ay
 distinct	peculiar,different,special,unique,several,varied,unlike,separate,various,noticeable,distinctive,distant,definite,particular,other,discrete,specific,diverse
@@ -6175,10 +5838,8 @@ communicated	delivered,disclosed,spread,recorded,proclaimed,noted,released,condu
 laboratories	workshop,lab
 motivation	desire,motive,life,ethics,morality,encouragement,yeast,wish,stimulus,spur,reason,catalyst,need,boost,fuel,impulse,incentive,urge,interest,momentum
 hector	thug,enemy
-booksellers	
 much	material,very,exceptionally,consequential,more,regularly,often,exceptional,serious,significant,remarkable,big,major,considerably,meaningful,historic,highly,frequently,substantial,such,important,distinguished,extremely,indeed,some
 hammer	beat,cut,stamp,forge,draw,fashion,pound,mold,create,work
-indirectly	
 horizons	scope,heavens,prospect,skies,perspective,boundary
 governance	politics,power,reign,control,leadership,government,authority,legislation,regime,rule,law,regimen,jurisdiction,administration,management,governing,sovereignty
 pinch	goose,grip,grab,crush,hurt,tweak,squeeze,theft,nip
@@ -6192,7 +5853,6 @@ coated	brushed,closed,backed,painted,polished,enclosed,decorated,hidden,capped,p
 brazil	amazon,acre,brazilian,santos,para,rio,brasil,natal
 mother	mummy,momma,ma,mom,parent,mommy,mum,mama
 cereal	barley,wheat,rice,corn,grain
-andrew	
 shots	burst,shooting,blast,artillery,discharges,firing,thunder
 bethlehem	round
 railroad	rail,railway,road,metro,line,tube,underground,subway,elevated,el
@@ -6220,7 +5880,6 @@ alarms	suggestions,notices,predictions,announcements,alerts,warnings
 rated	earned,deserved
 deductible	clause
 placements	jobs,appointments,assignments,rankings,commissions,positions,choices,elections,investments,nominations,selections,destinations
-paralegal	
 fines	punish,levy,penalties,damages
 captures	trap,seize,lands,draws,gets,gains,earns,taking,seizure,makes,carries,grab,occupy,achieves,conquer,wins,take,bags,catch,imprisonment,occupation,secure,acquires,arrest
 unfortunate	black,unsuccessful,fatal,inappropriate,poor,adverse,destructive,homeless,damaging,unhappy,catastrophic,miserable,doomed,pathetic
@@ -6229,12 +5888,10 @@ cabbage	bucks,change,gold,tender,money,scratch,currency,chips,green,coin,dollar,
 ghost	zombie,demon,angel,devil,shade,shadow,spirit,phantom,vampire,soul,vision
 ceramics	art,porcelain,pottery
 coral	maroon,crimson,wine,rose,glowing,tree,flaming,cardinal
-miami	
 required	prescribed,incumbent,necessary,essential,compulsory,vital,recommended,imperative,urgent,mandatory,appropriate,requisite,enforced,needed,forced
 mariners	sailors,salts
 ghana	africa
 monitoring	oversight,steering,charge,review,remark,care,observation,patrol,inspection,information,direction,government,regulation,note,perception,observing,leadership,investigation,experience,view,measurement,policing,examination,guidance,control,stewardship,protection,running,supervision,knowledge,consideration,administration,management,research,conclusion,surveillance,study
-zoloft	
 silent	dumb,quiet,mum,mute
 recruits	employs,jobs,retains,hires,pays,fees,places
 wlan	lan,wifi
@@ -6248,13 +5905,11 @@ outbreak	burst,disruption,surge,increase,explosion,onset,recurrence,plague,epide
 complaints	objections,criticism,protest,charge,trouble,grievance,protests,objection
 scar	mark,flaw,defect,vaccination,crater,mar,stain,fault,wound,spot,injury,distortion,symptom
 recommendations	instructions,order,data,sanction,feedback,charge,solutions,endorsement,information,proposal,instruction,tips,support,suggestions,proposition,suggestion,guidance,advice,inputs,judgment
-cocos	
 pairs	marry,braces,duo,partnerships,couples,two,couple,mate,teams,combination,match,combine,team
 municipal	civil,internal,governmental,public,government,domestic,civic,democratic,federal,national
 landlords	letters
 cathedral	tower,monument,hall,church,mansion,palace,structure,castle
 goodman	householder
-kraft	
 article	item,essay,provision,chapter,passage,column,clause,piece,editorial,report,reprint,detail,separate,theme,story,paragraph,commentary,feature,paper
 daughter	derivative,child,kid,offspring,son,girl
 coupons	certificates,tickets,vouchers,checks,passes
@@ -6316,7 +5971,6 @@ designation	banner,description,name,title,handle,nickname,appointment,recognitio
 flood	fill,stream,niagara,river,tide,flow,surge,tsunami,wave,swamp,overflow,bath,waterfall,rush,sweep,blizzard,avalanche,torrent
 dominate	lead,subordinate,manage,rule,reduce,run,subject,beat,override,overcome,reign,conquer,influence,smash,control,prevail,crush,command,defeat
 approves	clears,acknowledges,authorizes,confirms,sanctions,signs,warrants,accepts
-etc	
 lan	wlan,bus,wifi
 upright	moral,honorable,impartial,respected,honest,ethical,straightforward,straight,good,pure,decent,right,worthy,vertical,noble,just,correct,righteous,nice,proper,true,erect
 blessing	kindness,asset,plea,miracle,reward,gift,approval,backing,grace,permission,acceptance,support,backup,championship,dedication,reinforcement,consent,approving,adoption,prayer,petition
@@ -6375,7 +6029,6 @@ smoke	dust,dispatch,bomb,cap,gas,worst,vapor,paste,best,destroy,exhaust,bury,bea
 extensive	general,extended,expanded,major,vast,lengthy,wide,considerable,widespread,comprehensive,broad,large,huge,sweeping,pervasive,deep
 criterion	era,instance,precedent,measure,standard,grade,par,gauge,benchmark,metric,baseline,norm,rule,proof,principle,gpa,example
 suspense	coma,recession,latency,doubt,uncertainty,anxiety,suspension,tension,thriller,confusion
-interiors	
 egypt	cairo,africa,alexandria,egyptian,nile,memphis
 size	content,capacity,magnitude,diameter,breadth,big,measure,dimension,large,little,intensity,measurement,extent,perimeter,area,amount,height,range,small,distance,length,bulk,width,proportion,scope,volume
 troubles	illnesses,attacks,disorders,complaints,diseases,bugs,complications,conditions,infections
@@ -6398,7 +6051,6 @@ computing	process,measuring,counting,dividing,assessing,estimating,calculating,c
 chip	slice,disc,part,disk,fragment,particle,leaf,chop,hack,nick,section,bit,sheet,portion,cut,scrap,splinter,crack
 chesterfield	davenport,bench,chair,bed,sofa,ia,lounge,couch
 evolving	development,move,continuing,developing,shift,evolution,progress,proceeding,migration,expansion,improvement,action,change,operation,emerging,increase,exercise,act,current,advancement,growing,changing,shifting,successful,flow
-prozac	
 yosemite	usa,america,us
 glazed	ground,shiny,coated,polished,brushed
 remedy	pharmaceutical,right,therapy,fix,restore,relief,mitigate,medication,correct,alleviate,cure,drug,repair,solve,treatment,antibiotic,amend,pill,specific,relieve,prescription,medicine,medicinal
@@ -6410,10 +6062,8 @@ inlet	creek,basin,water,bay,recess,port,loch,cove,gulf,sea,lake,arm,harbor
 mounting	environment,shore,surroundings,support,body,climb,reinforcement,structure,context,stay,prop,brace,rise,bracket,mount,transport,trip,foundation,soaring,backdrop,ascending,location,arrival,spur,locale,framework,increasing,arch,departure,growing,ascension,pedestal,rising,cage,pillar,site,climbing,column,shuttle,fabric
 taxable	duty,tariff,excise,levy,assessment
 vulnerability	exposure,danger,susceptibility,threat,intrusion,sensitivity,weakness
-terrier	
 exceeding	primary,extraordinary,improved,extreme,main,also,big,considerable,uncommon,remarkable,preferable,unique,needless,striking,sublime,abstract,extensive,large,superior,inappropriate,unreasonable,higher,incredible,leading,new,other,singular,extra,further,improper,peculiar,dominant,ultimate,fantastic,good,outstanding,odd,noticeable,abnormal,supernatural,unfair,unusual,exceptional,rare
 debugging	amending,improving,modifying,changing,adjusting,repairing,correcting
-vaults	
 circulated	released,disclosed,spread,issued,declared,broadcast,reported
 sectors	zones,part,zone,regions,sections,districts,district,quarters,region
 invoked	brought,prompted,bred,induced,made,required,did,worked,created,prescribed,introduced,generated,effected,yielded,produced,caused,imposed,wrought
@@ -6429,8 +6079,6 @@ fly	circle,speed,fashionable,run,rush,go,move,smart,shoot,climb,cross,operate,pi
 continual	frequent,persistent,recurring,running,continuous,continuing,endless,enduring,repetitive,perpetual,recurrent,constant,repeated,perennial,continued,steady
 criticism	opinion,blast,critique,attack,comment,thrust,judgment,static,objection,review,assessment
 coded	encrypted,encoded
-frog	
-yoga	
 hey	gee,ha,glory,shout,wow,yahoo,cry,insertion
 follow	go,track,move,succeed,serve,support,watch,get,observe,shadow,attend,keep,reflect,replace,adopt,travel,seek,accompany,see,carry,accept
 industries	enterprise,labor,corporation,activity,persistence,diligence,application,attention,trade,care,effort,commerce,concentration,business,production,energy,management
@@ -6454,7 +6102,6 @@ respondent	witness,defendant,prisoner,communicator
 item	member,part,object,article,particular,portion,ingredient,constituent,thing,factor,incidental,point,characteristic,component,section,piece,detail,listing,element,list,information,place,position,feature,stuff
 tire	damage,fatigue,sap,wear,exhaust,bore,tyre,worry,jade,ring,waste,hoop,fail,hurt,drain
 member	councillor,constituent,commissioner,brother,pledge,sister,element,factor,associate,fellow,ingredient,conservative,component,basis
-truman	
 rooted	frozen,lifelong,settled,confirmed,inherent,intrinsic,deep,fixed,embedded,persistent
 repaired	refurbished,reversible,renovated,fixed,corrected
 makes	fashions,represent,go,move,do,organize,cause,establish,force,invest,manufacture,drive,get,start,draw,receive,pass,manufactures,forms,compose,generate,act,produce,collect,reach,think,form,creates,produces,require,frames,perform,create,constructs,meet,conduct,builds,head,prepare
@@ -6476,17 +6123,13 @@ golfing	piping
 teams	outfits,armies,parties,lineup,squad,club,corps,company,unit,companies,crews,organization,bands,departments,troops,gangs,party,side
 aide	helper,aid,servant,assistant,adjunct,maid,deputy,apprentice,lieutenant,supporter,mate
 accept	confirm,recognise,hold,have,obtain,believe,approve,affirm,take,trust,evaluate,undertake,honor,get,favor,respect,admit,observe,sign,submit,receive,tolerate,acknowledge,adopt,welcome,resign,buy,know,honour,embrace,comply,judge,agree,recognize,assume
-orange	
 onboard	congress,chamber,fraternity,guild,institution,chapter,consortium,fellowship,institute,collective,council,brotherhood,team,league,order,society,group,community,organization,association,club,college
 serve	deliver,function,provide,answer,make,follow,work,attend,pass,distribute,service,prelude,perform,benefit,handle,present,complete,give,do,accept
 rigorous	stringent,accurate,strict,brutal,demanding,correct,proper,hard,stern,tough,severe,precise,harsh,rigid
 lyons	tc,sc,soviet
 portals	gates,doors
 medal	silver,trophy,gold,honor,palm,ribbon,decoration,bronze,award,honour,prize,reward,order,crown,badge,title,laurel
-aspen	
 headaches	beasts,bears,troubles,jobs,killers,loads,efforts
-nelson	
-detox	
 overly	incredibly,exceptionally,super,highly,very,unusually,too,terribly,extremely
 festive	lively,happy,witty,playful,smiling,merry,jolly,bright,cheerful,funny,humorous,gala,sunny,laughing,amusing
 inflation	rise,vanity,confidence,hike,expansion,pride,boom
@@ -6496,23 +6139,19 @@ drought	lack,deficit,poverty,crunch,deficiency,shortage
 adding	extension,computation,inserting,estimate,inclusion,expanding,tagging,tying,counting,judgment,increasing,supplying,extending,calculation,adjoining,arithmetic,introducing,enhancing,forecast,prediction,estimation,fixing
 constructing	fusion,designing,construction,manufacturing,producing
 sa	militia,reserves
-sherry	
 assess	fine,rate,measure,fix,estimate,lay,determine,exact,evaluate,value,levy,mark,score,impose,gauge,weigh,charge,grade,check,judge,put,praise
 squares	fits,rhymes,chords,corresponds,consists,goes,equals,answers,sorts,checks,matches,agrees
 tactical	wise,prudent,useful,beneficial,profitable,practical,possible,desirable
 optimization	rise,raise,hike,development,gain,inflation,expansion,surge,merger,optimisation,increment,boost
 foolish	crazy,wacky,stupid,absurd,fond,mad,slow,silly,dumb,fantastic,mindless,unreasonable,ridiculous,weak,insane,fool,simple
 possibly	likely,certainly,sure,probably,surely,perhaps,maybe
-serves	
 october	oct
 discussed	considered,argued,cited,introduced,reviewed,disputed,specified,raised,quoted
 specifying	assigning,footnote,descriptive,defining,comment,indication,telling,ordering,reference,directing,prescribing,remark,arranging,notice,revealing,recognition,notification
 milling	pounding,grinding,beating
-raiders	
 yr	annum,decade,period,year
 comprising	pervasive,full,expanded,considerable,huge,global,broad,extensive,exhaustive,large,major,sweeping,lengthy,including,involving,thorough,containing,comprehensive,vast,complete,overall
 fountains	fonts,beginnings,origins,wells,springs,roots,sources
-flamingo	
 yearbook	monthly,yearly,newsletter,rag,mag,reference,organ,pictorial,edition,digest,weekly,bulletin,sheet,book,almanac,calendar,newspaper,serial,journal,review,magazine,periodical,gazette,zine,quarterly,annual,daily,paper
 sad	unhappy,bad,unfortunate,down,blue,distressed,depressed,disappointed,serious,miserable,worried,troubled,pathetic,upset,sorry,dark,tragic,moving
 wellness	hygiene,fitness,agility,healthy,health,strength
@@ -6522,7 +6161,6 @@ lowest	lesser,last,smallest,minor,minimum,small,smaller,low,minimal
 beaches	sands,shores,strands
 using	exploitation,applying,exercising,operating,employing,utilizing
 landmarks	memorial,museum,corners,marker,milestones,highlights,tree,milestone,monument,transformations,watershed
-hepatitis	
 dozens	bundles,yards,scores,volumes,masses,hundred,tons,hundreds,piles,stacks,loads,lots,thousands,quantities
 bse	worship
 renamed	named,labeled,termed,denoted,dubbed,labelled,branded,specified
@@ -6538,12 +6176,10 @@ entered	pierced,accessed
 possessions	prosperity,kit,revenue,substance,effects,equipment,accessory,machinery,goods,apparatus,material,abundance,cash,property,holdings,security,instrument,junk,worth,supply,riches,gear,treasure,luggage,things,harness,stuff
 merger	connection,combining,takeover,blend,synthesis,junction,fusion,coupling,consolidation,union,merging,linking,combination,connecting
 form	practice,process,way,build,mode,object,organize,develop,establish,sort,letter,figure,found,stem,behavior,structure,fashion,base,shape,law,pattern,variety,acquire,questionnaire,configuration,application,model,appear,word,method,make,arrangement,radical,cast,singular,abbreviation,format,geometry,forge,root,work,plan,outline,assemble,compose,acronym,constitute,system,theme,thing,character,manner,condition,order,construct,design,plural,create,rule,scheme,set,complete,style,regulation
-scalable	
 supervise	direct,run,monitor,build,head,steer,boss,handle,manage,administer,oversee,conduct,order,guide,inspect,command,control
 marsh	wash,wetland,mud,swamp
 dashed	run,rushed,ran,bounded,depressed,skipped,broken
 fingerprint	criterion,marker,stamp,quality,symbol,trait,mark,sign,indication,property,touch,character,point,characteristic,affection,diagnostic,print,hallmark,loop,specific,attribution,note,feature,badge,attribute
-nad	
 grape	wine
 swimming	diving,floating,turning,dive,swim,plunge,dip,spinning
 embraced	public,crushed,familiar,held,accessible,ubiquitous,wrapped,grabbed,prevalent,universal
@@ -6573,10 +6209,8 @@ standardization	coordinate,stabilization,regulate,organize,integrate,order
 sudan	africa,darfur
 pending	open,imminent,unresolved,uncertain,hanging
 characteristics	features,marks,diagnostics,touches,attributes,quality,signs,specifics,essence,symbols,virtue,markers,stamps,qualities,symptom,tone,traits,criteria,characters,component,flavor,tendency,personality,nature,aspect,attribute,style,properties
-shaw	
 residents	public,people,center,state,inhabitants,natives,citizens,company,community,district,tenants,neighborhood,nation,culture,association,society
 judged	constitutional,considered,permissible,legitimate,prudent,responsible,conscious,authorized,lawful,concluded,liable,calculated,careful,weighed,heard,convicted,settled,cautious,proper,valid,sorry,wrong,contractual,thoughtful,decided,fair,resolved,deemed,legal,determined,statutory
-ted	
 hop	celebration,formal,prom,skip,leap,jump,dance,festival,ball,bound,event,spring,party
 achievement	creation,performance,victory,accomplishment,release,smooth,coup,credit,recruitment,triumph,arrival,action,going,pass,feat,realization,attainment,exploit,liberation,reaching,success,effort,masterpiece,walk,deed
 non	fairness
@@ -6643,17 +6277,14 @@ array	row,cluster,bundle,multitude,assortment,package,parcel,pattern,batch,bank,
 identifiable	generic,identifying,distinguishing,distinct,particular,pronounced,general,peculiar,typical,classic,proper,distinctive,special,characteristic,diagnostic,individual,usual,attributable,specific,normal
 executing	constant,burning,applying,running,functioning,enforcing,performing,working,execution,administering,implementing,hanging
 rite	celebration,office,custom,watch,tradition,ritual,ceremony,occasion,procedure
-cisco	
 stupid	dense,soft,insane,trivial,crazy,unreasonable,opaque,simple,ignorant,dull,mad,slow,dim,mindless,foolish,thick,irrelevant,silly,dumb,naive
 rocky	stony,tough,tricky,rugged,unstable,rough
 cause	move,regulate,objective,force,purpose,found,initiate,source,invoke,pioneer,bring,shape,determine,matter,mold,motivate,induce,make,motivation,facilitate,occasion,faith,promote,root,work,lead,encourage,plan,goal,begin,generate,movement,produce,spawn,reason,effect,yield,motive,principle,create,introduce,prompt,breed,element,influence,origin,ideal,explanation,do
 tent	roof,pavilion,shelter,ceiling,guy,cover,dome,umbrella,canopy,canvas
 owl	sniper,thief,pirate,criminal
-decker	
 improvements	growth,development,progress,rise,innovations,enhancements,advance,discoveries,change,increase,renovation,advances,advancement,recovery,enhancement,gain,developments,upgrade,revision
 petty	lesser,narrow,minor,little,partisan,provincial,trivial,small,rigid
 logistics	governance,engineering,administration,manipulation,planning,leadership,stewardship,guidance,government,provision,operation,running,supervision,supplying,strategy,oversight,management,control,handling,agency,coordination,care,presidency,conduct,direction,regulation
-snp	
 law	measure,statute,case,aggregation,precedent,legislation,requirement,enactment,constitution,code,collection,ordinance,act,amendment,charter,order,prohibition,charge,decree,mandate,rule,decision,ruling,accumulation,proposal,bill,regulation
 bracket	sort,family,variety,tier,genus,species,division,type,league,order,category,classification,section,grade,set,group,class,kind,generation
 induced	invoked,brought,prompted,bred,made,did,worked,created,generated,effected,yielded,produced,caused,wrought
@@ -6676,7 +6307,6 @@ dread	panic,awe,terror,dire,horror,trying,scary,shocking,horrible,terrible,fear,
 predator	beast,animal,shark,kite,fauna,creature,user,wolf,vampire
 galveston	tx
 gap	interval,difference,break,void,breach,divide,opening,separation,gulf,cut,hole,disagreement,division,rent,crack
-arthritis	
 mentally	interior,inner,psychological,cognitive,cerebral,internal,intellectual
 chain	continuum,nexus,progression,bracelet,cable,series,group,train,sequence,attach,string
 rejected	ignored,empty,void,abandoned,dropped,discarded,neglected,vacant,forgotten
@@ -6706,7 +6336,6 @@ collaborations	teamwork,mergers,interactions,unions,partnerships,dealings,associ
 offset	remedy,correct,negative,relieve,balance,equal
 lookup	search,pursue,hunt,seek
 badges	tokens,symbols,attributes,logos,trademarks
-tuna	
 manifesto	opinion,conclusion,resolution,platform,decree,declaration,decision,ruling,verdict,call,announcement,fiat,judgement,directive,diagnosis,bull,determination
 ultimately	yet,basically,someday,eventually,soon,sometime,finally
 contention	belief,controversy,guess,thesis,assumption,dispute,submission,struggle,theory,discussion,opinion,plea,conflict,idea,speculation,hypothesis,assertion,claim,position,explanation,argument
@@ -6722,12 +6351,9 @@ composer	musician,songwriter
 facsimile	duplication,portrait,replica,twin,spit,ringer,equivalent,double,picture,carbon,clone,counterpart,duplicate,fetch,image
 picking	choice,nomination,naming,decision,collection,selection,choosing,selecting,draft,election,pick,option,excerpt
 usher	direct,lead,take,steer,marshal,marshall,conduct,accompany,show,route,guide,initiate,pilot
-ra	
 illegally	dirty,too,overly,extremely
-hendrix	
 alcoholic	soak,hard,lush,drunk
 afforded	provide,obtained,allow,grant,offer,covered,acquired,got,manage,took,purchased,offered,secured,went
-peruvian	
 divisions	borders,fences,partitions,barriers,boundaries,walls
 businessman	retailer,suit,baron,trader,seller,purchaser,king,operator,owner,merchant,tycoon,buyer,power,vendor,entrepreneur,dealer
 voter	constituent,taxpayer,citizen,crossover,resident
@@ -6748,7 +6374,6 @@ suffers	witnesses,has,support,feels,sees,tastes,encounter,have,hurt,experiences,
 shin	thigh,ham,pin,calf
 revenue	gate,interest,wealth,pay,sum,credit,receipt,salary,receipts,earnings,gross,profit,return,fund,amount,yield,proceeds,dividend,gain,income,stock,money
 norwegian	norwegian
-pc	
 fruit	development,seed,crop,acorn,olive,consequence,fate,conclusion,issue,result,berry,product,grain,sequence,spike,child,produce,ear,effect,aftermath,hip,sequel,pod,outcome,implication,nut
 chaser	pop,brandy,brew,belt,performance,sauce,nip,slug,peg,ale,conclusion,bottle,climax,drink,liquor,rum,mum,shooter,lush,shot,show,spirits,defender,sake,gin,vapor,whisky,whiskey,wine,mead,beer,juice,load,cocktail,alcohol,attitude,tot,vodka
 jerk	beast,creep,bounce,thrust,dog,bump,nerd,idiot,cad,wrench,draw,rat,nuisance,pull,hound,heel,cur,pill,lug,snake,fool,clown,flop
@@ -6758,11 +6383,8 @@ senses	sensations,sense,feels,reasoning,feelings,logic
 pouch	pocket,backpack,sack,bag,package,purse
 scary	disturbing,dread,dire,shocking,hairy,horrible,terrible,creepy
 timeout	downtime,break,recess,breath,interruption,pause,winter,suspension
-marlin	
 projection	anticipation,estimate,expansion,portion,bump,knot,increase,knob,swelling,calculation,section,piece,bunch,forecast,prediction,estimation,dome,block,mound,swell
-opal	
 linden	wood,lime
-quark	
 wisdom	insight,sanity,judgment,understanding,savvy,knowledge,intellect,sensitivity,intelligence,experience,caution,perception
 coats	piles,jackets
 thickness	layer,thick,thin,diameter,breadth,depth,gauge,width,sheet,density,dimension,consistency
@@ -6773,7 +6395,6 @@ grade	size,course,quality,peg,chapter,step,notch,level,phase,inch,amount,cut,con
 blend	fuse,mixture,complement,synthesis,fusion,cocktail,composite,brew,combine,integrate,compound,combination,merge,assortment,alloy,mix,fit,blending
 managerial	commanding,administrative,executive,governmental,legislative,organizational,ministerial,regulatory,supervisory
 wander	stray,swan,float,go,hike,move,stroll,err,cruise,travel,drift,range,roll,cast,trek,rove
-hebrews	
 atp	nucleotide
 mud	sludge,soil,dirt,sand,clay,gravel
 proclaimed	announced,noted,described,disclosed,authorized,posted,recorded,declared,prevalent,assigned,widespread,ordered,shared,published,unclassified,current,advertised,aired,expressed,broadcast,charged
@@ -6860,7 +6481,6 @@ spreading	epidemic,infectious,diffusion,spread,travel,dispersion,scattering,inva
 scented	spicy,aromatic,sweet
 dart	butterfly,zip,slight,slap,hurry,attack,name,fleet,bound,dash,offence,flash,cut,float,dis,barb,personality,insult,sprint,dig,offense
 possibility	incident,expectation,risk,circumstance,probability,likelihood,capability,opportunity,potential,hazard,prospect,action,hope
-antilles	
 overwhelmed	moved,affected,surprised
 fri	friday
 annex	appendix,wing,extension,addition,penthouse,addendum,supplement,append
@@ -6869,14 +6489,12 @@ discharges	shots
 degree	angle,status,size,extreme,magnitude,quality,sort,rate,low,strength,term,credit,chapter,step,honor,level,qualification,severity,intensity,extent,phase,scale,spf,mild,inch,property,amount,caliber,cut,point,stage,grade,high,standard,grind,depth,class,intense,place,position,scope,aspect,side
 spain	madrid,toledo,valencia,barcelona,europe,seville,eu,basque,ec,leon,nato
 domestic	interior,household,municipal,residential,internal,national,indigenous
-philip	
 pirate	rover,raider,corsair
 cement	glue,epoxy,size,plaster,concrete,sand,bond,adhesive,mud
 tiffany	sheer,clear,thin,silky,pure
 aurora	day,daylight,dawn,sun,light,sunrise,morning
 liver	dwell,reside,local,citizen,native,tenant,resident,inmate,abide,stay
 fixing	restoration,alteration,conversion,revise,modification,reconstruction,variation,improvement,repairing,remodeling,change,redesign,overhaul,transformation,correction,reform,adjustment,amendment,repair,fixture,difference,maintenance,tweak,care,revision
-apache	
 border	rim,bounds,hem,margin,frame,circuit,bound,line,perimeter,edge,skirt,outpost,entrance,surround,boundary,fringe,neighbor,compass,end
 memphis	tennessee,tn
 tremendous	cosmic,grand,extraordinary,titanic,bumper,big,considerable,huge,heroic,substantial,great,excellent,mega,mighty,large,mammoth,oversized,terrible,galactic,incredible,terrific,marvelous,monster,giant,super,fantastic,immense,massive,good,wonderful,awesome,amazing,enormous,planetary,gigantic,oceanic,astronomical,vast,fabulous,exceptional
@@ -6903,9 +6521,7 @@ liter	dl,litre,dal,l
 thirteen	xiii
 plea	petition,suit,appeal,apology,trial,desire,application,claim,overture,prayer,explanation,cry,demand,action,argument,solicitation
 detect	catch,encounter,locate,spot,trace,reveal,ascertain,determine,find,sense,discover,distinguish,get,spy,observe,expose,identify,learn,disclose,see,uncover,notice,recognize
-lisp	
 adopted	public,favored,approved,accessible,ubiquitous,familiar,prevalent,universal
-multilingual	
 performers	players,ensemble,band,crew,association,cast,gang
 cur	snake,coward,dog,chicken,funk
 venues	media,locale,site,setting,platforms,outlets,forums,place
@@ -6932,12 +6548,10 @@ tenants	guests,residents,holder,roommates,resident,visitors
 mama	mommy,girl,mom,female,parent,mum,mother,mummy,grandmother,ma,woman,momma
 ingredients	elements,items,bases,constituents,characteristics,factors,members,technique,components,method,prescription,program
 incorporating	combining,collection,integrating,absorbing,assortment
-fitzgerald	
 sea	water,inlet,neptune,bay,recess,blue,waters,ocean,deep,gulf,lake,pond,surf
 qi	spirit,life,vitality,chi,aura,light,nature,karma,ki,soul,energy
 getaways	flights,escapes,slips,breaks
 breaker	fuse,wave,curl,surge,roller,surf,swell
-gregory	
 steel	sword,iron,metal,fe,alloy,brace,blade
 airways	lanes,passes,portals,routes,drives,roads,trails,waterways,gateways,channels,approaches,streets,paths,arteries,rows,passages,gates,pike,ways,doors,highways,avenues
 flap	fly,hang,confusion,overlap,dag,fever,covering,rage,chaos,fury,turbulence,frenzy,tongue,flop
@@ -6958,7 +6572,6 @@ consoles	cabinets,presses
 ness	land,peninsula,earth,ground,spit,point,tongue,cape
 rotterdam	holland,netherlands,nederland
 dresden	deutschland,germany
-gods	
 davis	day,june
 france	riviera,nice,lyons,nato,alps,brittany,champagne,burgundy,cannes,bordeaux,midi,toulouse,eu,basque,lorraine,provence,tours,europe,orleans,ec,lyon,nancy,centre
 consultancy	bargaining,negotiation,conversation,discourse,meeting,consultation,roundtable,seminar,consult,symposium,chat
@@ -6984,7 +6597,6 @@ reduce	dismiss,sack,bring,can,thin,cut,break,slash,force,bust,spill,trim,lower,u
 softly	silently,gently,herb,smoothly,quietly,low
 naive	simple,primitive,innocent,green,believing
 tableware	table,silver,cutlery,service,knife,setting,ware,fork,glassware,dinnerware
-tulip	
 agriculture	business,culture,farming,gardening,cultivation,horticulture
 saline	salt
 stoves	cookers,ovens
@@ -7002,7 +6614,6 @@ mart	exchange,store,showroom,boutique,superstore,emporium,shop,market,outlet,gro
 relaxing	entertaining,cozy,pleasant,dreamy,moving,lively,affecting,worthwhile,inspiring,funny,compelling,impressive,satisfying,convenient,easy,useful,exciting,appropriate,charming,pleased,rewarding,happy,soft,interesting,soothing,absorbing,fascinating,amusing,loose,humorous,engaging,warm,relaxed,healthy,stimulating,enjoyable,fun,delightful,appealing
 there	practical,honest,honorable,authoritative,proficient,authentic,decent,strong,solid,why,accurate,adequate,no,mature,qualified,talented,dependable,realistic,safe,able,skilled,apt,accomplished,eternal,what,sensible,capable,gee,trained,competent,hey,well,steady,licensed,lo,efficient,credible,upright,predictable,true,hello,decisive,suited,responsible,positive,ha,sincere,ethical,stable,good,smart,ah,indeed,intelligent,gifted,oh,experienced,convincing,seasoned
 presented	mounted,showed,conferred,given,displayed,performed,granted,offered,exhibited,staged,gave,carried
-hicks	
 bucket	myriad,hundred,plenty,sight,abundance,yard,barrel,quantity,vessel,peck,flood,mass,lot,store,bunch,can,dozen,much,deal,bundle,mountain,pot,ton,wealth,heap,chunk,pack,volume,loads,kettle,pile,stack,mess
 varieties	brand,assortment,strain,range,combinations,nature,category,character,array,blends,change,salads,mixture,diversity,quality,kind,breed,variation,soup,description,collection
 speed	rate,run,further,facilitate,help,pace,acceleration,fly,boost,momentum,advance,hurry,zoom,velocity,agility,c,ride,promote,rush
@@ -7011,7 +6622,6 @@ therapies	cure,remedies,analysis,solutions,remedy,answers,medicine,healing
 teamed	linked,connected,joined,grouped,sided,travelled,affiliated,tied,associated,wed,mixed,attached,sorted,bonded,related,coupled,allied,traveled
 expenditures	expenses,costs,rate,cost,spending,prices,output,consumption,price,figure,amount,investment,value,expense
 involved	sophisticated,active,complex,engaged,concerned,elaborate,interested,complicated,participating,varied,affected,difficult
-talbot	
 kin	folks,blood,race,lineage,house,dynasty,family,tribe,relative,people,clan,household,stock
 lettering	magazine,signature,photograph,caption,newspaper,manuscript,script,copy,writing,book,handwriting,stamp,edition,engraving,type
 wastes	losses
@@ -7025,7 +6635,6 @@ addiction	monkey,dependence,alcoholism,habit,dependency,jones,tolerance
 ufo	phantom,shadow
 gloss	appearance,colour,annotate,color
 soon	shortly,presently,rapidly,early,instantly,now,quickly,directly,promptly,immediately
-gastric	
 condensed	sturdy,thick,substantial,tough,solid,compact,tight,dense,close,compressed
 surge	climb,swell,rise,grow,growth,tsunami,flood,flow,wave,stream
 slip	tumble,sneak,slide,fall,dock,pier,anchorage,decline,steal,mistake,move,glide,creep,decrease,drop,trip,shrink,shift,error
@@ -7039,12 +6648,8 @@ someday	shortly,subsequently,yet,soon,ultimately,finally,sometime,eventually
 marine	oceanic,underwater,naval,maritime,saltwater,aquatic,coastal,nautical,man
 prey	beast,target,creature,quarry,victim,chase
 interviewing	surveying,polling,questioning
-dominic	
 emissions	discharges,flights,radiation,flows,discharge
-astrophysics	
-todd	
 stimuli	reasons,incentives,incentive,catalyst,motivation,encouragement,stimulation
-helpdesk	
 furniture	lamp,equipment,closet,cabinet,bed,sheraton,goods,sofa,wardrobe,table,nest,sectional,couch,counter,chair,appliance,chest,appointments,furnishing,desk,dresser,seat,things,bureau,furnishings,buffet,press
 earnest	urgent,sincere,strict,thoughtful,grave,sober,distinguished,severe,stern,harsh,professional,passionate,serious
 eds	perception
@@ -7071,10 +6676,8 @@ retention	conservation,retaining,procurement,care,ownership,custody,storage,hold
 withdrawn	retiring,reserved,backward,shy,lone,modest
 promotion	advancement,marketing,message,upgrading,preference,upgrade,creation,pitch,advertisement,pr,plug,content,rise,endorsement,hype,elevation,advert,advertising,publicity,packaging,ad,substance
 timed	deliberate,careful
-gibraltar	
 killer	headache,labor,individual,soul,job,beast,person,effort,slayer,somebody,mortal,suicide,terminator,bear,burden
 especially	specifically,principally,exclusively,personally,specially,particularly,notably
-abuses	
 overlay	wrap,cover,carpet,sheet,coat,blanket
 ships	vessels,yachts,liners,boats
 healthier	fit,sturdy,hardy,active,tough,well,strong,agile,robust,improving,good,hale,lively,rugged,whole,bouncing,vigorous,sound
@@ -7101,12 +6704,10 @@ guideline	standard,order,blueprint,counsel,programme,regulation,code,counselling
 timeshare	condo,apartment,townhouse
 predicts	forecast,conclude,warns,calls,forecasts,promises,announces,anticipate,call,reads,think,declares
 mainland	earth,continent,ground,land
-bluegrass	
 satisfied	fulfilled,pleased,glad,content,convinced,happy,cheerful,thrilled,thankful,delighted
 nowhere	ordinary,bland,near,no,dull,detached,dumb,regular,annoying,tired,none,everyday,nothing,boring,stupid,never,darkness,extinction,moderate
 hereford	cattle,durham,galloway,longhorn,cows,angus
 longer	soul,individual,better,someone,person,further,large,somebody,lengthy,also,big,extensive,extended,over,too
-crosses	
 beach	seaside,waterfront,shoreline,coast,sand,strand,shore,coastline
 supervision	regulation,management,care,administration,oversight,control,supervising,surveillance,stewardship,observation,policing,government,leadership,guidance,monitoring,direction,charge,instruction
 tic	pattern,curiosity,tendency,practice,habit,character,attribute,characteristic,trait,trick,personality,attitude,property,twist
@@ -7142,7 +6743,6 @@ basel	switzerland
 aims	propose,trains,target,desire,sets,try,ambition,levels,intend,objective,intention,focus,direct,intent,plan,direction,focuses,holds,purpose,heads,want,directs,mean,sights,wish,design,casts,address
 probe	exploration,verify,inspection,scrutiny,hear,research,examine,inquire,inquiry,try,dig,study,probation,probing,investigate,examination,investigation
 sacramento	california
-banjo	
 debts	obligations,liabilities,bonds,bankruptcies,scores
 automate	change,modify,alter
 host	receive,army,crush,flock,presenter,drove,mob,bike,present,manager,array,multitude,owner,mass,anchor,moderator,millions,horde,herd,masses,introduce,legion,crowd,press
@@ -7155,7 +6755,6 @@ argos	greece
 topics	contents,motives,ideas,matters,issues,subjects,problems,questions,themes
 batch	assortment,group,block,band,battery,grouping,set,shipment,variety,accumulation,parcel,quantity,array,aggregate,amount,lot,bunch,aggregation,cluster,package,clutch,bundle,mixture,suite,bank,volume,series,collection
 driver	jockey,trainer,operator,racer
-mp	
 tailed	ran,tracked,followed,watched,run,accompanied,tagged,pursued,traced
 shanghai	cop,prc,impress,steal,spirit,capture,seize
 gear	fit,equipment,tailor,adapt,accessory,regulate,material,accommodate,instrument,adjust,pitch,machinery,luggage,stuff,tackle,harness,kit,supply,hardware,costume,apparel,dress,apparatus,facilities,organize
@@ -7166,13 +6765,10 @@ slam	beat,strike,bang,bat,crash,slap,hit,batter,lock,belt,shut,dash,blast,smash,
 version	history,performance,story,account,interpretation,variant,form,variation,report,adaptation,translation,approximation,tale,reading
 customary	accustomed,usual,going,accepted,prevailing,standard,normal,popular,conventional,traditional,prevalent,current
 gulf	harbor,water,port,inlet,bay,loch,arm,cove,sea,creek
-presses	
 professions	declarations,announcements,allegations,claims
-hitchcock	
 junior	lesser,minor,small,inferior,subordinate,secondary,lower,smaller,less
 congress	legislature,senate,legislative,parliament,council
 default	neglect,negligence,failure,absence,oversight
-naples	
 blew	play,pump,waste,rush,blast,drive,flow,wave,whistle,stream
 contexts	settings,media,locations,situations,elements,background,places,environments,text,surrounds,surroundings,situation,spaces
 important	urgent,imperative,noteworthy,influential,key,consequential,chief,principal,material,grand,crucial,primary,foremost,grave,prominent,fundamental,distinguished,cardinal,supreme,master,notable,measurable,strategic,substantial,central,alpha,heavy,much,outstanding,leading,necessary,significant,powerful,exceptional,dominant,decisive,meaningful,major,prime,burning,eminent,valuable,beta,remarkable,historic,big,essential,vital,main,importance,serious,great,relevant,critical
@@ -7188,7 +6784,6 @@ communicator	individual,sender,author,promoter,ambassador,somebody,presenter,tra
 speeding	ready,movement,rapid,rushing,prompt,acceleration,running,fast,flying,motion,operating,effective,move,swift,alive,fleet,racing,accelerated,lightning,quick,speedy
 assumption	if,theory,given,thesis,guess,hypothesis,hypothetical,proposition,belief,inference,scenario,doctrine,suspicion,basis,assertion,conclusion,premise,acceptance,principle,condition,expectation
 fetch	come,take,deliver,cost,yield,bring,run,retrieve,earn,carry,convey,transport,get,transmit,sell,obtain,produce,transfer
-deaf	
 evaluated	assessed,valued,rated,analyzed,estimated,set
 costa	structure
 dispose	discard,adapt,deposit,put,place,junk,locate,remove,set,toss,retire,stick,abandon,lay,scrap,trash,park,dump,position,waste,fix,plant
@@ -7210,7 +6805,6 @@ allowances	shares,portions,cuts,takes,parts,proportions,percentages,pieces,slice
 pleasures	treats,hobby,purpose,amusement,bliss,desire,delights,comfort,satisfaction,enjoyment,thrill,luxury,joy
 scaling	climb,measuring,ascension,estimating,ordering,spanning,order,evaluating,assessing,weighing
 capture	realize,arrest,taking,get,represent,obtain,garner,grab,draw,win,earn,imprisonment,occupy,carry,conquer,achieve,make,land,seizure,attain,secure,occupation,gain,trap,take,reap,acquire,catch,seize
-burger	
 looks	presence,makes,seems,appearance,feels,character,presentation,sounds,image,appears,look,acts
 timing	preceding,past,present,timeliness,middle,early,coming,lead,late,succeeding,future,approaching
 engaging	fascinating,sweet,inviting,attractive,pleasant,interesting,intriguing,magnetic,absorbing,pleasing,exciting,appealing,charming
@@ -7218,7 +6812,6 @@ colony	body,plantation,outpost,province,camp,colonial,territory,settlement
 favourite	sweet,special,fond,pet,dear,precious,darling,loved,favored,favorite,beloved
 compliments	approval,praise,suggestion,regard,congratulations,encouragement,greetings,request,acknowledgement,date,challenge,nod,regards,proposition,petition,salute,hello,solicitation,blessing,respects,overture,reception,bid,appeal,wish
 development	change,result,increase,process,evolution,advancement,progress,progression,flowering,growth,emergence,outcome,expansion,improvement,issue,situation
-mara	
 dag	g,gm,gram,hg
 dock	float,harbor,pier,enter,quay,marina,wharf,landing,anchor
 biological	legitimate,natural,birth
@@ -7236,7 +6829,6 @@ gem	gemstone,masterpiece,art,brilliant,rock,ornament,treasure,stone,hardware,jew
 make	play,work,represent,draw,compose,bring,clear,reproduce,establish,conduct,pass,start,cause,collect,sire,move,drive,incorporate,piece,force,perform,invoke,receive,institute,copy,form,style,write,get,raise,chop,meet,act,stir,go,father,mother,direct,require,bear,create,build,fashion,short,frame,generate,beat,realize,do,cut,yield,film,prepare,extract,blast,produce,initiate,reach,shell,organize,offset,strike,construct,forge,manufacture,give,multiply,assemble,track,fire,tack,organise,grind,head,derive,realise,invest,think,press
 five	hundred,v,dough,twenty,two,chips,buck,ten,money,fin,one,cash,currency,fifty,dollar
 remained	prevail,stop,endure,live,survive,waited,stand,continue,wait,stayed,last,persist
-staining	
 younger	petty,lesser,slight,flowering,secondary,trivial,juvenile,negligible,teenage,adolescent
 bail	gage,bond,take,pledge,deposit,security,withdraw,earnest,guarantee,warranty,warrant
 filename	extension,name
@@ -7252,14 +6844,12 @@ ithaca	greece
 geisha	japanese
 description	summary,confession,specification,illustration,rendering,variety,nature,characterization,type,sort,definition,character,version,portrait,spec,sketch,statement,story,detail,narrative,report,explanation,account,information,tale,picture
 reasonably	wisely,well,pretty,nicely,fairly,kindly,somewhat,moderately,honestly
-bd	
 considering	since,as,for,now,seeing,whereas,because
 socialism	left,ideology
 internship	apprenticeship,training,spot,position,place,office,post,situation
 intuition	insight,instinct,feel,inspiration
 celebrate	mark,perform,praise,observe,carol,keep,worship,honor,cheer,hymn,salute,bless
 trust	business,corporation,lean,confidence,group,assign,charge,faith,believe,rely,protection,swear,depend,commit,task,count,calculate,hope,institution,care,account,bank,credit,expectation,look,bet
-squid	
 sensory	visual,sensual,sonic,auditory,neural,neurological,sensitive
 disappointment	mistake,failure,blow,sorrow,frustration,regret,obstacle,disaster,defeat,sadness
 benign	white,safe,encouraging,kind,warm,healthy,mild,friendly,favorable,innocent,kindly,harmless,gentle,sound
@@ -7300,7 +6890,6 @@ disasters	harm,collapse,failure,accidents,crash,tragedy,emergency,hazard,flood,d
 defender	firefighter,fighter,hero,champion,guardian,custodian,reminder,keeper,monitor,guard,tribune,protector,supporter,watchdog,protection,sponsor
 restrictive	regulatory,restricting,definitive,exclusive,selective,limiting
 supports	stays,assist,strengthen,relief,reinforce,continue,help,raise,encouragement,back,justify,brackets,pillars,assistance,establish,columns,loyalty,responsibility,boost,encourage,aid,protection,sponsor,finance,payment,tolerate,abide,backing,shores,props,fund,endorse,take,braces,care,hold,promote,maintain,spurs,stands,approve,foundations,mounts,subsidy
-kellogg	
 surveying	measurement,survey,review,polling,inquiry,analysis,study,search,measuring,inspection,probe,measure,research,planning,scrutiny,case,architecture,design,intelligent,hearing,interviewing,examination
 missionaries	soldiers,monks,bishops,preacher,ministers,clergy,scholars,religious,apostles,priests,pastor,messenger,students,teacher
 unified	incorporate,cooperative,incorporated,merged,centered,polarized,combined,integrated,concentrated,consolidated,united,centralized,coordinated
@@ -7337,7 +6926,6 @@ aggregation	library,fauna,class,band,string,grouping,defence,parcel,flora,array,
 needles	misery,panic,suspense,trouble,doubt,dread,worry,uncertainty,concern,suffering
 syndicated	contributed,reprinted,marketed,manufactured,distributed,published,edited,printed,produced
 prospects	landscapes,forecast,risk,views,opportunity,possibility,prospect,expectation,perspectives,chance
-crossword	
 positive	practical,hopeful,pragmatic,confident,constructive,worthwhile,supportive,specific,clear,optimistic,approving,beneficial,useful,accepting,helpful,effective,reasonable,friendly,decisive,productive,complimentary,good,favorable
 nationwide	ethnic,civil,social,interstate,countrywide,democratic,governmental,government,public,comprehensive,internal,municipal,communal,national,domestic,federal
 adobe	clay
@@ -7358,7 +6946,6 @@ ratios	rates,rate,proportion,scale,proportions,quota
 paris	france
 fails	breaks,drop,neglect,crashes,break,finish,stalls,fall,decline,end,dies,close,ignore
 warehouses	magazines,bins,containers,banks
-neo	
 market	business,advertise,retail,activity,request,monopoly,demand,display,marketplace
 poetry	verse,song,genre
 kernels	cores,meats,contents,roots,nets,nuclei,sums,subjects,hearts,themes,points
@@ -7449,7 +7036,6 @@ tom	tomcat,kitty,kitten
 stolen	hooked,lifted,appropriated,seized
 originals	examples,prototypes,sources,classics,models
 consultation	interview,argument,debate,counsel,dialog,consultancy,session,talk,meeting,consult,conference,appointment,dialogue,discussion,conversation,audience,hearing,council,examination
-percy	
 chairperson	moderator,speaker,chair,chairman,president
 module	system,spacecraft,member,component,factor,sector,constituent,item,section,lot,detail,measure,capsule,segment,side,element,chunk,unit,piece,any,share
 swap	change,commute,exchange,interchange,replace,switch,shift,trade,substitute
@@ -7502,16 +7088,13 @@ establish	prove,formulate,form,initiate,build,open,install,make,institute,create
 distressed	anxious,upset,worried,disturbed,troubled,restless
 patagonia	argentina,chile
 basket	pocket,crate,bucket,sack,carrier,cooler,locker,trunk,cartridge,bowl,box,holder,container,bin,case,carton,bag
-ux	
 jfk	kennedy
 invalid	challenged,sick,delicate,lame,weak,fading,null,fragile,dying,false,unreasonable,poorly
-compton	
 bremen	germany
 wearing	painful,hostile,trying,strict,biting,rigorous,grinding,stringent,uncomfortable,overwhelming
 disease	epidemic,plague,illness,sickness,cancer,sign,flu,disorder,stroke,infection,ill,attack,virus,condition,symptom,anthrax,contamination,fever,syndrome,inflammation,bug,defect
 engage	face,join,participate,lock,close,attract,pursue,interest,practice,arrest,seize,gain,act,absorb,occupy,grab,undertake,commit,involve,draw,busy,capture,hold,move,win,meet,catch,grip,employ
 grass	clearing,pasture,field,meadow,ground,timothy,barley,bluegrass,cereal,parcel,hay,plot,plat,turf,lawn,tract,green,bent
-hoover	
 rash	epidemic,sudden,daring,flood,wave,spontaneous,rushed,flying,swift,rush,bold,rapid,breathtaking,quick
 prevail	dominate,prove,beat,overcome,rule,win,conquer,reign,override,triumph,succeed
 basic	elementary,primary,essential,grassroots,main,introductory,key,basal,vital,beginning,simple,primitive,fundamental,radical,elemental,underlying,necessary
@@ -7527,7 +7110,6 @@ tester	analyst,controller,scientist,sampler,agent,auditor,prosecutor,police,inve
 preserves	jam,maintains,conserve,jelly,saves,protects,preserve
 citizenship	liberation,community,origin,behavior,release,exemption,conduct,society,immunity,democracy,privilege,autonomy,sovereignty,relief
 spent	used,weary,wasted,done,beat,tired,finished,exhausted,lost,dead,beaten,limp,worn,drained
-inverness	
 leukemia	cancer
 contaminated	savage,corrupted,infected,dangerous,corrupt,vicious,combined,crooked,violent,messy,blended,diluted,hot,infamous,stained,dirty,rotten,nasty,wicked,mixed,muddy,dusty,filthy,cruel
 scores	amount,grade,get,files,record,loads,mark,result,notch,total,reach,tons,gain,count,account,rate,connect,scratches,mills,lots,tally,number,add,average,win,accomplish,piles,dozens
@@ -7539,7 +7121,6 @@ relevant	compatible,consistent,useful,suited,appropriate,pertinent,applicable,im
 avalanche	overflow,tide,slide,waterfall,stream,niagara,torrent,river,surge,flood
 pesticide	virus,toxic,poison,cancer,spray,disease,chemical,venom
 understandable	acceptable,reasonable,predictable,coherent,straightforward,logical,obvious,simple,accessible
-gemini	
 confidentiality	discretion,privacy,understanding,friendship,isolation,confidence,mystery,affection,familiarity,secrecy,silence
 highland	surge,elevation,cliff,mountain,hillside,slope,bluff,rising,plain,ridge,plateau,mound,hill,dune,climb
 making	stuff,production,potential,material,timber,substance,possibility
@@ -7593,7 +7174,6 @@ rushing	fast,driving,flying,swift,fleet,accelerated,run,ready,racing,lightning,r
 till	register,reap,tend,plant,harvest,crop,farm
 band	corps,belt,loop,camp,eye,orchestra,bunch,troop,tape,collection,pack,hoop,collar,round,company,line,circle,party,set,gathering,cohort,conspiracy,ring,club,lot,gang,crew,ensemble,symphony,coil
 heartbeat	pulse,minute,instant,shake,wink,flash,second,moment,pounding,beat
-thermal	
 feeling	sadness,sensation,suspicion,shame,pleasure,instinct,warmth,awareness,sympathy,state,affection,complex,taste,despair,heart,liking,enthusiasm,chord,culture,feel,spirit,appreciation,temper,behavior,understanding,excitement,passion,intensity,aura,perception,pain,reaction,sensitivity,gravity,quality,thought,humor,impression,dislike,affect,hope,humour,concern,thing,compassion,gratitude,attitude,sentiment,stab,glow,happiness,sense,opinion,atmosphere,view,pride,soul,belief,emotion,mood,notion,expectation,desire
 caring	noble,warmth,constructive,humanitarian,helpful,suitable,timely,mild,soft,crucial,significant,faithful,concern,prospect,friendly,favorable,nice,plan,dear,thinking,opinion,active,expectation,theory,thoughtful,true,cooperative,valuable,dream,important,liberal,worry,maternal,kindly,supportive,image,sensitive,gentle,view,concerned,interested,compassionate,passionate,patient,dedicated,productive,practical,sympathetic,love,understanding,responsive,conclusion,useful,kind,invaluable,devoted,knowledge,touching,profitable,applicable,accessible,judgment,worried,intention,romantic,earnest,loving,generous,charitable,essential,hope,assessment,affected,humane,anxiety,feeling,belief,warm,notion,loyal,convenient,benign
 feat	exploit,coup,achievement,victory,rally,deed,accomplishment,stunt,success,adventure,triumph,number,trick,performance,effort,hit
@@ -7616,7 +7196,6 @@ lou	awful,grim
 federated	affiliated,associated,unite,married,partial,unfair,allied,united,involved,biased,partisan,merged
 ethanol	liquor,drink,alcohol,smoke
 fridge	refrigerator,freezer
-lloyd	
 voting	advancing,option,offering,choice,polling,posing,veto,presenting,bouncing,ballot,proposing,suggesting,selection,recommending,submitting,pick,vote
 renaissance	pinnacle,history,revival,prime,glory,millennium,flower,renewal,zenith
 proposals	offers,plans,motion,offer,project,scheme,program,overture,recommendation,proposition,idea,plan,bid,recommendations,outline,suggestions,ideas
@@ -7625,9 +7204,7 @@ redeem	offset,answer,complete,repay,fill,fulfill,compensate,deliver,meet,accompl
 antibiotic	drug,medicine,remedy,medication,injection,pill,serum,tablet,cure,pharmaceutical,botanical,medicinal,prescription,specific
 mac	macintosh,workstation,waterproof,trench,laptop,pc,mack
 pushed	drove,moved,thrust,forced
-pays	
 nh	us,america,manchester,concord,dartmouth,portsmouth,usa
-albert	
 expected	scheduled,awaited,predicted,likely,proposed,anticipated,due
 mason	artisan,manufacturer,worker,architect,producer,contractor,builder,inventor,maker
 planetary	gigantic,giant,great,terrestrial,mammoth,titanic,cosmic,monster,mighty,world,huge,worldwide,galactic,substantial,global,vast,tremendous,immense,grand,heroic,enormous,oceanic,big,majestic,major,international,massive,oversized,considerable,astronomical,bumper,jumbo,good,mega,super
@@ -7674,7 +7251,6 @@ skiing	traverse,athletics,sport
 observations	thought,regards,reflection,research,examination,review,conclusion,view,opinion,remark,inspection,perception,knowledge,experience,note,commentary,study,submissions,surveillance,investigation,information,finding,respects,consideration,measurement
 bayer	bayer,aspirin,salt
 amazingly	unusually,rarely,uniquely,remarkably,beautifully,surprisingly,suddenly
-zen	
 deadline	period,limit
 millionaire	capitalist,have,tycoon,money
 rainy	misty,moist,damp,wet,pouring
@@ -7692,12 +7268,10 @@ pharma	company
 assists	boost,facilitate,advice,aids,sustain,cooperate,aid,reinforce,services,back,support,help,benefit,supports,guidance,hands,lifts
 leaning	pitched,inclined,cant,listing,oblique,sentiment,diagonal,graded
 breeze	hurry,current,breath,air,puff,cruise,waltz,blow,sail,zip,glide,wind,gale
-da	
 outgoing	direction,past,animated,social,effluent,gay,outward,jolly,spirited,outbound,preceding,retiring,friendly,cheerful,lively
 illusions	ideas,deception,image,visions,fantasy,myth,confusion,dreams,fantasies
 albums	readers,compilations
 answers	remarks,result,solution,reactions,feedback,remark,explain,argue,claim,returns,resolution,acknowledge,comment,report,clarify,observation,do,explanation,justification,solve,return,meet,sign,defend,comments,resolve,key,response,deny,replies,statement,respond,interpretation,responses,say
-ibis	
 acceleration	clip,pace,speed,velocity,rate,tempo,speeding
 lee	hand,part,rear,bottom,sector,front,border,outside,surface,top,right,view,side,face,left,foot
 extended	expanded,continued,tropical,prolonged,symbolic,long,lengthy,extensive
@@ -7752,7 +7326,6 @@ disaster	apocalypse,tsunami,holocaust,plague,hazard,flood,crash,visitation,failu
 mortgage	debt,pledge,engage,promise,contract,commit
 derby	helmet,tam,hood,hat,helm,panama,fedora,lid,cap
 yemen	asia,arabia
-isolates	
 board	order,commission,director,guild,fellowship,group,council,chamber,committee,jury,collective,community,enter,organization,panel,consortium,accommodate,catch,league,chapter,association,directorate,brotherhood,institute,team,fraternity,congress,college,cabinet,society,institution,club
 flaws	faults,bug,defect,weakness,fault,failing,weaknesses,abnormalities,defects,stains,scars,marks
 helps	service,facilitate,assists,save,support,guidance,restore,boost,backs,advice,encourages,comfort,back,cooperate,cooperation,maintain,further,ease,promotes,use,encourage,guides,push,facilitates,saves,aid,promote,serve,supports,stimulate,hand,aids,alleviate,treat,worker,benefit
@@ -7763,7 +7336,6 @@ chest	breast,bin,trunk,vault,locker,compartment,box,crate,torso,body,bust,case,h
 orbit	rotation,pattern,circle,steps,track,way,path,pathway,route,course,loop,itinerary,line,arc,trajectory,circuit
 having	acquisition,partnership,control,gain,possession,purchase,property,keeping,holding,takeover,hands
 familiar	loving,dear,simple,tight,usual,familiarity,friendly,close,known,aware,comfortable,easy,inward,beaten,old,social,near,intimate,thick
-karen	
 wrong	error,brutal,bush,injustice,poor,crime,prejudice,evil,defective,erroneous,wanting,rotten,off,pathetic,lacking,correctness,mistaken,horrible,unfair,false,flawed,bad,cheat,violation,unacceptable,insult,inferior,incorrect,harm,punk,slight,sour,funny,ill,illegal,unhappy,insufficient,lame,improper,grievance,awful,mistake,terrible,bias,unlawful,deficient,inaccurate,inadequate,useless,abuse
 happier	lucky,favorable,promising,unexpected,fortunate,hopeful,convenient
 donation	assistance,gift,offering,endowment,contribution,appropriation,relief,subsidy,allowance,philanthropy,aid,grant,subscription,charity,help
@@ -7778,7 +7350,6 @@ contributions	donations,donation,addition,charities,offerings,grant,input,increa
 quicker	wise,rapid,summary,immediate,responsive,speedy,eager,ready,vigorous,active,agile,willing,alert,energetic,clever,keen,instant,sudden,able,prompt,smart,brief,swift,fast,sharp,effective
 garbage	junk,lumber,debris,truck,trash,litter,dust,scrap,rubbish,refuse,waste,sewage
 warrant	approve,undertake,license,require,leave,allowance,signature,permit,confirm,accreditation,explain,passport,ticket,granting,certificate,authorization,affirm,clearance,consent,ensure,pledge,sanction,licence,permission
-apollo	
 twenty	one,ten,chips,cash,currency,money,hundred,fin,two,fifty,dollar,buck,five,cardinal
 described	summarized,told,showed,noted,drew,precise,demonstrated,thorough,suggested,comprehensive,illustrated,represented,painted,disclosed,defined,exact,supposed,expressed,complicated,pictured,stated,rendered,proclaimed,exhaustive,displayed,specific,announced,depicted,reported,characterized,recorded,related,accurate,definite,portrayed
 wacky	queer,crazy,funky,bizarre,absurd,unusual,remarkable,curious,foolish,outrageous,odd,silly,wild,weird,strange,funny,peculiar,unpredictable,unique
@@ -7791,7 +7362,6 @@ enable	alter,gift,equip,allow,facilitate,change,empower,let,prepare,implement,pe
 committees	panel,board,commission,cabinet,chamber,panels,bureau,missions,jury,commissions
 standalone	discrete,independent,disconnected,individual,private,free,separate,detached,single
 fist	paw,hand,mesh,rope,secure,glove,grip,bay,hold,arrest,clutch,corner,grasp
-dinar	
 removable	transferable,adjustable,movable,moving,flexible,portable,modular,mobile
 junk	debris,trash,slack,camp,lemon,dust,scrap,rubbish,mess,nonsense,cheese,bomb,clutter
 vision	illusion,spirit,ideal,view,insight,perspective,aspect,perception,imaging,mirage,conception,imagery,nightmare,outlook,dream,fantasy,understanding,idea,presence,imagination,fiction,picture
@@ -7807,7 +7377,6 @@ functions	service,dos,reception,power,duty,occasions,business,operation,benefits
 arbor	screen,roof,box,shelf,ceiling,shelter,furniture,canopy,dome,drive,shield,counter,spindle,pavilion,bed,tent,cover,umbrella,shaft
 findings	research,biography,charge,composition,citation,decisions,bill,essay,holdings,history,data,sentences,rulings,warrant,collection,detention,knowledge,poetry,accumulation,brochure,prose,leaflet,novel,lore,information,judgments,statement,article,prosecution,drama,story
 advantages	leverage,wealth,jumps,allowances,power,benefits,support,leads,choice,protection,gain,profit,odds,drops,influence,favor,improvement,recognition,interest,preference,opportunities,position,convenience,starts,return,asset,dominance,pulls,edges,lead,margins,privileges,edge
-engagements	
 airfare	fare
 mammoth	super,cosmic,big,bumper,oceanic,immense,giant,gigantic,vast,planetary,enormous,grand,astronomical,substantial,tremendous,massive,jumbo,mighty,oversized,majestic,titanic,heroic,galactic,huge,large,monster,considerable,mega,great
 forest	vegetation,park,tree,grove,timber,flora,botany,timberland,jungle,underwood,woodland,wood,woods
@@ -7821,7 +7390,6 @@ tradition	content,prescription,standards,form,wisdom,habit,culture,legend,law,no
 tcp	protocol
 secretion	hiding,caching,burial
 regime	legislature,governance,government,power,state,authorities,sovereignty,division,bench,bureaucracy,executive,reign,organization,jurisdiction,administration,court,empire,rule,regimen,leadership,management,authority,tyranny,establishment,brass,palace,system,judiciary,organisation
-hamas	
 oxide	dioxide,silica,lime,compound
 shocks	contacts,impacts,encounters,kicks,collisions,blows,strikes,crashes
 xs	delete,cancel,erase,remove
@@ -7849,7 +7417,6 @@ trio	trilogy,composition,opus,triple,piece,trinity
 editors	broadcasters,reporters,columnists,journalists
 relying	susceptible,leaning,conditional,depending,counting,calculating
 zones	belts,parts,lands,regions,districts,territories,corridors
-ir	
 auxiliary	supporter,complementary,accessory,additional,helper,added,aide,peripheral,supplementary,assistant,supplemental
 paddle	splash,pole,navigate,kayak,wade,square,pull,row,boat,drift,canoe
 unnamed	one,unidentified,unsigned,anonymous,certain,unspecified,some,unknown
@@ -7871,7 +7438,6 @@ footnote	notation,reference,note,excerpt,caption,footer,authority,annotation,exp
 collage	blend,salad,shuffle,variety,image,tumble,litter,assortment,accumulation,medley,jungle,hash,motley,stew,combination,clutter,picture
 partisan	concerned,supporter,colored,distorted,hostile,interested,partial,biased,sympathetic,defender,influenced
 trek	ride,journey,trip,excursion,cruise,migrate,expedition,voyage,tour,flight,hike,odyssey
-apoptosis	
 granny	grandmother,grandma,nan,ancestor
 rarely	little,occasionally,seldom,never,barely,hardly,sometimes
 santiago	chile
@@ -7882,10 +7448,8 @@ scientist	expert,investigator,analyst,individual,person,chemist,psychologist,som
 kindergarten	school,academy,prep,seminary
 cows	devon,threatens,bull,ox,bullock,shocks,grade,steer,herd,bos,beef,cattle,bovine,cow,calf,welsh,pressures
 migrant	immigrant,refugee,traveler
-julian	
 hierarchical	ranked,graded,vertical
 disc	audio,ring,splinter,plate,scrap,chip,sheet,bit,tray,portion,section,part,lp,slab,layer,particle,sphere,leaf,dish,fragment,slice,disk
-canton	
 operated	managed,controlled,fulfilled,manipulated,worked,run,used,wrought,regulated,ran,handled,drove,negotiated
 beau	man,lover,sweetheart,fellow,boyfriend,boy,husband
 strollers	travelers,passengers,travellers
@@ -7906,11 +7470,9 @@ price	fee,assessment,charge,reduce,damage,figure,valuation,discount,value,bill,e
 jackets	capsules,shells,coatings,cases,cartridges,covers,plates,packages,shields
 severely	roughly,hard,sharply,critically,firmly,extremely,badly,strictly,seriously,ill,strongly
 undertaking	offer,bid,assay,attempt,go,operation,proposition,project,venture,breeze,essay,struggle,pass,assignment,effort,enterprise,work,try,task,experiment,striving,adventure,affair,endeavor,snap,endeavour,picnic,trial,baby,marathon
-dat	
 spray	aerosol,squirt,splash,shoot,dot,dust,spot,shower,pepper
 dec	christmas,xmas,december,noel
 vip	superstar,notable,star,personality,name,hero,somebody,light,celeb,celebrity,icon
-amd	
 waited	stayed,hang,watch,await,awaited,stay,delay,expect,remained,expected,remain
 blogging	chronology,memoir,version,narrative,testimony,site,tale,journal,history,report,log,commentaries,witness,chronicle,commentary,documentation,record,diary,annals,story
 hale	robust,well,drive,bouncing,fit,strong,hardy,force,sound,healthy,squeeze,sturdy,whole,pressure,railroad,act,move
@@ -7927,13 +7489,11 @@ planners	designers,pioneers,builders,founders,developers,researchers,makers,crea
 bred	trained,produced,cultured,generated,reproduced,raised,cultivated,multiplied
 strength	capability,capacity,weak,energy,concentration,effectiveness,power,spirit,health,strong,courage,delicate,property,might,virtue,muscle,vitality,stability,horsepower,force,asset,weight,depth,sense,durability,rugged,competence,competency,validity
 varying	changing,variable,differing,volatile,irregular,unstable,inconsistent,shifting
-microscope	
 eventually	yet,sometime,soon,promptly,immediately,finally,shortly,ultimately,someday
 scratch	grind,delete,meet,jar,contact,pull,withdraw,claw,clash,rub,touch
 mf	array
 trusted	honorable,commissioned,dependable,sure,charged,reliable,devoted,credible,established,honored,loyal,assigned
 visitation	disaster,call,visit
-seoul	
 weave	create,fold,fuse,lace,ply,construct,blend,spin,sew,shoot,snake,loop,incorporate,mesh,mix,compose,knit,introduce,twist
 bulk	volume,majority,total,extent,number,amount,mass,figure,weight,quantity
 enhancing	upgrading,helping,fancy,amending,exquisite,improving,refining,ornamental
@@ -7947,8 +7507,6 @@ smile	laugh,grin,beam
 accused	suspect,condemned,convicted,guilty
 duo	team,pair,twain,partnership,couple,composition,opus,piece
 polynesia	oceania,tonga
-tyne	
-ascii	
 resurrection	renewal,revival,renaissance,regeneration,restoration
 expertise	ability,experience,skills,professionalism,skill,proficiency,competence,facility,savvy
 pink	warm,tanned,red,brown
@@ -8022,7 +7580,6 @@ simulated	substitute,process,manipulated,imitation,faux,manufactured,fake,design
 fame	praise,popularity,recognition,character,glory,dignity,status,name,reputation,acclaim,celebrity,honor
 precursor	indication,angel,prototype,sign,herald,symptom
 shortest	little,tiny,small,low,slight
-pda	
 accepted	tried,endorsed,customary,material,confirmed,recognized,genuine,established,universal,welcomed,acknowledged,actual,popular,hard,experimental,real,approved,authorized,fashionable,recognised,empirical,conventional,preferred,received,factual
 perfectly	fully,exceptionally,totally,utterly,thoroughly,pat,wonderfully,finely,dead,correctly,ideally,wholly,specially,completely,quite,entirely,altogether
 tempted	enchanted,trapped
@@ -8072,7 +7629,6 @@ terminate	close,determine,lift,alter,halt,discharge,settle,eliminate,resolve,kil
 crusade	movement,demonstration,campaign,war,reform,venture,blitz,drive,cause,effort,expedition,project,push,march,initiative,feminism
 excess	extreme,redundant,extra,additional,surplus,spare,waste,unwanted,unnecessary
 down	downhill,downstairs,off,below,downward,over,low
-alto	
 dedication	adherence,allegiance,commitment,devotion,fidelity,loyalty,attachment
 wives	companion,roommate,companions,ladies,brides,bride,women,partners,spouses,spouse,partner
 points	moments,commitment,percentage,division,advantage,ratio,fee,percent,bonus,chunk,participation,proportion,minutes,influence,interest,royalty,involvement,earnings,seconds,dividend,right,contribution,stake,benefit,rate,gain,part
@@ -8092,7 +7648,6 @@ insisted	repeat,alleged,request,asserted,proclaimed,press,affirmed,demand,hold,c
 personnel	police,mp,people,manpower,workforce,service,hands,organization,patrol,staff,help,troops,worker,law,employee,force,troop,rank,men,pool,organisation,military,group,crew
 filth	grease,garbage,rubbish,stain,dust,trash,sewage,sludge,soil,litter,dirt,junk
 miracles	wonder,wonders,marvel,phenomenon,surprise,phenomena,sensations,revelation
-zaire	
 passes	carries,transfers,reaches,hands,bucks,gives
 tagging	tracing,pursuing,chase,trailing,pursuit,chasing,following,tracking,search
 rub	insult,problem,coat,brush,gauge,apply,headache,wipe,bother,cover,curse,nuisance,run,worry,blur,grind,pest,wear,touch,inconvenience,paint,frustration,guide,discomfort,strain,scrub,spread,burden,smooth,pass,clean,pat,trial
@@ -8120,11 +7675,9 @@ restart	resume,proceed,preserve,renew,continue,restore
 laptop	workstation,pc
 solitaire	silver,jewelry,glass,ornament,treasure,gemstone,gold,pendant,necklace,paste,gem,costume,jewel,bracelet,earring
 redistribution	division,distribution,allocation,issuance
-nobel	
 prophecy	prediction,prognosis,predicting,forecasting,anticipation,forecast,sign,apocalypse,revelation
 nil	zip,null,o,oh,nothing,zero
 ironing	binding,tying,sewing,restricting,joining,limiting,linking,garment,housekeeping,securing
-raf	
 suggestion	approach,tip,proposition,cue,instruction,lead,resolution,motion,suspicion,charge,hint,idea,notion,recommendation,sign,proposal,thought,opinion,invitation,indication,clue
 designated	primary,labelled,exclusive,extraordinary,particular,known,major,titled,proper,individual,limited,memorable,main,certain,peculiar,specified,unique,appropriate,unusual,renowned,different,specific,noted,exceptional,named,labeled,specialized,celebrated,personal,appropriated,dubbed,famous,rare,significant,termed,booked
 wagering	gambling,betting,laying,offering,putting,playing
@@ -8163,7 +7716,6 @@ pudding	duff,dessert,sweet
 mover	commissioner,shipment,traveler,remover,broker,officer,transit,carrier,transportation,handler,deputy,vehicle,worker,lawyer,representative,operator,transport,radical,minister,promoter,immigrant,operative,shipping,assistant
 optimal	sterling,prime,terrific,top,splendid,fantastic,choice,maximum,capital,best,optimum,fabulous,great,excellent,marvelous,outstanding,special,swell,exceptional,supreme,classic,superb,grand,nifty,superior,stellar,exquisite,distinguished
 runs	trips,races,speeds
-dolphin	
 ascending	ascension,higher,mounting,up,climbing,elevated,growing,steep,climb,high,upward,soaring,rising,overhead,upper,raised,increasing
 dogs	hunters,puppies
 chickens	snakes
@@ -8180,7 +7732,6 @@ authorized	approved,certified,commissioned,official,authorised,empowered,license
 actions	behavior,conduct,manners,trait,presence,bearing,address,attitude
 enhancements	advances,developments,improvements,innovations
 contact	interaction,relation,talk,influence,reach,placement,connect,association,touch,insider,in,telephone,visit,meeting,phone,unity,somebody,approach,call,connection
-anime	
 apostle	advocate,herald,supporter,friend,promoter,christian,champion,booster
 sources	fonts,wells,starts,origin,origins,cause,beginnings,authority,springs,fountains,expert,roots
 texas	amarillo,south,colorado,odessa,waco,paris,tx,garland,galveston,us,lubbock,austin,arlington,bryan,tyler,usa,plano,sherman,america,houston,dixie,midland,red,southwest,dallas,beaumont,canadian,victoria
@@ -8189,7 +7740,6 @@ aries	individual,someone,ram,person,soul,somebody
 witches	wizards
 troubled	scared,haunted,upset,stressed,struggling,obsessed,careful,annoyed,anxious,worried,restless,confused,tense,nervous,suffering,concerned,distressed,disturbed,bothered,tortured
 thursday	weekday
-antigua	
 portrayed	pictured,illustrated,painted,expressed,decorated,represented,photographic,defined,described,characterized,depicted,rendered,visual,vivid,descriptive,illuminated
 append	supplement,attach,expand,insert,annex,introduce,add
 feelings	mood,disposition,affinity,enthusiasm,passion,passions,spirit,unity,understanding,temper,excitement
@@ -8221,7 +7771,6 @@ specimens	personalities,bodies,characters,customers,birds,devils,ducks,men,guys,
 retired	retiring,quiet,isolated,private,covert,hidden,solitary,discharged,elderly,remote,secret,lone,lonely,resigned
 multitude	bike,myriad,mob,horde,flock,millions,crush,drove,army,pack,crowd,herd,press,legion,host,masses,mass
 reboot	boot
-tahiti	
 cardiology	medicine
 perspectives	shoes,angle,minds,viewpoint,aspect,views,viewpoints,angles,feelings,opinions,context,attitude,prospect
 arabia	arabian,oman,arab,asia,yemen,qatar
@@ -8249,11 +7798,9 @@ functioning	live,active,operating,living,on,going,operational,operative,running,
 conn	guide,head,steer,navigate,direct,pilot,helm,point
 commandments	requirements,directions,instructions,commands,orders,directives,charges,words
 returned	replaced,restored
-july	
 excitement	boot,bang,passion,charge,warmth,incentive,buzz,stimulus,frustration,rage,emotion,joy,confusion,kick,frenzy,motivation,thrill,feeling,rush,adventure,stimulation,drama,encouragement
 antibody	monoclonal,protein,disease,virus,bug,ig
 ft	foot,inch,in,pace,yard
-pt	
 rag	serial,bulletin,newspaper,mag,organ,periodical,magazine,gazette,tag,book,zine,paper,journal
 reflected	reproduced
 mighty	huge,massive,robust,strong,prominent,heavy,powerful,influential,senior,potent,imposing,large,significant,enormous,magnificent,important
@@ -8280,7 +7827,6 @@ oncology	medicine
 hell	part,misery,nightmare,pit,underworld,region
 appraisals	impressions,judgments,feelings,assessments,estimates,evaluations,beliefs,notions,perceptions
 offender	defendant,suspect,cheat,principal,attacker,criminal,shark
-jukebox	
 entirely	all,totally,full,exclusively,clean,fast,well,exactly,only,completely,fully,wholly,utterly,quite,altogether,even,solely,out,dead,wide,absolutely,enough,flat,entire,basically,perfectly,thoroughly,whole,alone
 increased	accrued,enlarged,expanded,multiplied,accumulated,elevated,extreme,high,up,raised,enhanced,maximum
 licensing	clearance,support,granting,allowance,approval,permission,tolerance,authorization,allowing,letting,permitting,license,consent,sanction,licence,prescription,promotion,leave,endorsement,okay
@@ -8288,7 +7834,6 @@ subordinate	lower,helper,less,smaller,aide,assistant,minor,servant,deputy,associ
 reef	barrier,stall,restraint,hardship,interference,delay,burden,difficulty,disadvantage,load,danger,brake,constraint,beach,arrest,hazard,curb
 woven	mixed,twisted,blended
 superstore	emporium,market,showroom,shop,exchange,bazaar,mart,marketplace,outlet,boutique
-pong	
 meridian	noon,zenith,mature,acme,climax,pinnacle,summit,apex,peak,crest,head,top,crown,sum,height
 range	assortment,kind,compass,dimension,cover,field,stretch,selection,palette,vary,pallet,view,collection,reach,drift,length,horizon,matter,orbit,extent,space,latitude,yard,ranch,lot,sort,contrast,territory,line,variety,area,pasture,prairie,lea,spectrum,differ,go,scope,spread
 counts	totals,scores,amounts
@@ -8312,8 +7857,6 @@ weekday	friday,monday,fri,wednesday,saturday,sat,th,wed,mon,thursday,tuesday
 formula	strategy,blueprint,design,process,arrangement,procedure,instruction,program,method,plan,project,technique,operation,plot,system,recipe,approach,prescription,course,scheme
 noble	extraordinary,charitable,splendid,humane,distinguished,great,worthy,honorable,imposing,grand,royal,gentle,magnificent,brilliant
 nominees	candidates,delegates
-ie	
-asses	
 crushed	packed,busted,collapsed,cracked,shattered,routed,loaded,rough,damaged,overwhelmed,defective,full,injured,broken,destroyed
 warrants	certificate,signatures,leaves,permissions,permission,passport,seals,pledge,sanctions,approve,permits,allowances,permit,ensure,accreditation,license,ticket,licences,undertake,sanction,affirm,explain,licenses,require
 sizes	measures,dimensions,proportions,areas,measurements
@@ -8322,7 +7865,6 @@ excluding	breach,exclusion,except,besides,saving,but,oversight,beside,failing
 united	collective,incorporated,consolidated,cooperative,coupled,linked,allied,integrated,agreed,unified,compatible,merged,confederate,federated,unanimous,tied,homogeneous,one,peaceful,incorporate,joint
 arab	palestinian,arabia,arabian
 transplantation	operation,surgery
-whitney	
 helpless	unable,vulnerable,weak,exposed,susceptible
 converters	mechanisms,transformers,mills,motors,machines,appliances,engines,tools
 alleged	hypothetical,presumed,conceptual,assumed,academic,questionable,theoretical,supposed,stated,proposed
@@ -8333,7 +7875,6 @@ dig	find,take,remove,clean,withdraw,enter,understand,catch,scoop,harvest,root,st
 panama	cap,derby,hat,hood,fedora,helm,helmet,tam,colon
 processes	step,means,treat,convert,procedures,courses,techniques,progress,handle,activities,movement,procedure,measure,systems,action,refine,methods,transform,technique,way,operation,operations,alter,mechanism,case,proceedings,system,practice,growth,manners,ways,trial,course,proceeding,development,rule,prepare,approaches
 kid	toddler,juvenile,orphan,youth,teenager,child,son,teen,girl,joke,fry,boy,buster,bother,chick,infant,bud,monkey,squirt,cub,adolescent,minor,baby,tot,daughter,tease,silly,peanut
-moses	
 shown	advertised,unveiled,proclaimed,exhibited,produced,displayed,exposed,announced
 bye	pass,concession
 keyboard	key,console,computer,action,organ,keypad,device,piano,manual,terminal
@@ -8353,7 +7894,6 @@ departed	soul,somebody,faded,dying,done,mortal,dead,gone,deceased,zombie,someone
 enabling	clearance,support,granting,approval,permission,licensing,allowing,letting,permitting,consent,submission,sanction,licence,promotion,facilitation,endorsement,ok,okay,compliance,encouragement
 daytime	evening,eve,sunshine,candle,lamp,ray,dawn,lantern,day,daylight,glow,sun,period,even,sunlight,window,flash,morning,star,afternoon,bulb,radiation
 nodes	knots,tumors
-medline	
 pumping	jerking,tap,draw,rocking,push,shaking,supply,swinging,drain,pour,send
 complies	observe,submit,agrees,satisfy,obey,quit,accepts
 days	life,stretch,span,career,era,term,stage,survival,history,mornings,date,day,generation,period,cycle,time,season,duration,course,evenings,age
@@ -8393,7 +7933,6 @@ argue	question,support,dispute,reason,present,insist,demonstrate,clarify,conside
 disadvantage	defect,deprivation,limitation,harm,obstacle,disability,debit,strike,negative,penalty,prejudice,liability,handicap,minus
 escaped	unleashed,free,loose
 damn	huge,stark,pure,profound,damned,genuine,darn,complete,horrible,definite,fair,clean,deadly,terrible,endless,blank,real,utter,dead,thorough,outright,constant,crashing,flat,sheer,absolute,stone,very,rank,regular,curse,perfect,simple,total
-samurai	
 pub	saloon,tavern,cafe,inn,nightclub,cabaret,lounge,bar
 incorrectly	wrong
 modifications	variations,changes,revisions,differences,alterations,shifts,adjustments
@@ -8409,7 +7948,6 @@ roof	ceiling,cover,pavilion,dome,house,protection,building,tent,umbrella,canopy,
 erotica	creation
 bolt	bound,latch,escape,dart,spike,pipe,jerk,start,skip,leap,sprint,flee,dump,dash,rush,jump,rod
 seeker	hunter,competitor,nominee,applicant,candidate,finder,someone,individual,person,soul,hopeful,somebody,prospect
-radiology	
 calculate	weigh,approximate,guess,count,survey,fraction,estimate,reason,resolve,compute,budget,forecast,process,solve,measure,consider,sum,tally,assume,figure,extract,adjust,multiply,evaluate,determine,divide,average,integrate,differentiate,factor,judge,add,gauge,anticipate,assess
 tokyo	japan
 allows	release,assign,tolerate,support,authorize,authorizes,has,recognize,favor,provide,approve,suffers,admits,permits,give,grant
@@ -8424,7 +7962,6 @@ bang	suddenly,rap,soon,quick,hit,now,smash,directly,slam,promptly,bash,shortly,a
 gut	bowel,stomach,belly,empty
 themed	motif,topic,problem,question,matter,essence,purpose,content,motive,idea,subject,issue
 underlying	essential,basal,elemental,elementary,basic,introductory,hidden,implicit,fundamental,beginning,simple
-herring	
 memorable	interesting,enduring,decisive,terrific,unforgettable,famous,important,meaningful,noteworthy,historic,remarkable,notable,great,impressive,extraordinary
 difficulty	misery,hassle,pressure,struggle,sweat,stress,frustration,dilemma,trial,controversy,anxiety,worry,obstacle,hazard,discomfort,effort,inconvenience,crisis,trouble,hardship,pain,dispute
 abused	crushed,repetitive,helpless,ordinary,distressed,dry,exploited,flat,stupid
@@ -8435,7 +7972,6 @@ paging	requesting,inviting,commanding,call,ordering,ringing,asking,yell,paging,s
 accessible	cheap,inexpensive,popular,available,discount,handy,affordable,usable,low
 lat	back
 aesthetic	artistic,handsome,cute,fascinating,fair,appealing,gorgeous,taking,likely,attractive,pretty,glorious,sublime,good,elegant,creative,beautiful,lovely,charming,exquisite,stunning
-automation	
 apparent	possible,noticeable,presumed,obvious,putative,plausible,plain,supposed,likely,probable,superficial,clear,evident,visible,distinct,assumed,understandable,manifest,alleged
 palestine	jordan,asia
 anything	everything,all,something
@@ -8459,13 +7995,10 @@ hound	canine,hector,dog,bother,bloodhound,pack,pursue,afghan,puppy
 contiguous	neighboring,adjacent,immediate,joining,attached,nearest,touching,adjoining,united,close,closest
 poet	bard,muse,author,writer,artist
 trout	fish
-kangaroo	
 tasting	having,passing,sample,receiving,experiencing,seeing,undergoing,feel,suffering,sustaining,bite,appreciate,sip,enduring,feeling,enjoy,knowing,eat,chew
 retail	distribute,marketing,merchandising,market,wholesale,sell,merchandise
 unaware	awareness,ignorant,consciousness,unfamiliar,innocent,asleep,unconscious
 checksum	verification,check
-thomas	
-lev	
 vienna	austria
 streak	band,blaze,stripe,bar
 origin	commencement,root,source,influence,element,ancestry,descent,home,birth,birthplace,head,well,motive,fountain,genesis,connection,cradle,lineage,spring,font,beginning,ancestor
@@ -8538,7 +8071,6 @@ inquire	challenge,examine,inspect,consult,ask,question,investigate,communicate
 referee	ref,judge,magistrate,moderator
 dicks	shadows,investigators
 mary	madonna
-ect	
 laundering	bathing,deleting,cleaning,laundry,editing,bath,wash,sewing,housekeeping,reviewing,cleansing,shampoo,washing
 bracelets	constraints,ties,chains,bonds,bands,collars,irons,traps,binds
 slavery	imprisonment
@@ -8563,7 +8095,6 @@ forward	onwards,on,dispatch,out,address,leading,forwards,along,promote,forth,tra
 spectacular	elaborate,dressed,marvelous,magnificent,fantastic,dramatic,enriched,grand,enhanced,daring,amazing,loud,trimmed,fabulous,splendid,impressive,decorated,extreme,stunning,breathtaking,baroque,remarkable,striking
 debug	rewrite,revise,remedy,amend,improve,change,reform,adjust,right,modify,repair,correct
 facts	data,information
-eastern	
 concert	presentation,sing,festival,gig,musical,performance,show
 citations	accolades,prizes,awards
 youngest	flowering,adolescent,teenage,new,juvenile
@@ -8606,7 +8137,6 @@ stout	durable,tough,tenacious,hardy,robust,rugged,sturdy,healthy,vigorous,hard,s
 graphite	lead,c,carbon,pencil
 edited	read,published,amended,improved,altered,revised,compiled,annotated,adjusted,polished,printed,updated
 reversed	reverse,rear,backward,converse
-angus	
 localization	locating,finding,determination,location
 butts	seats,cans,bottoms,beams,cheeks,tails
 polymer	compound,dna,silicone,rna
@@ -8632,7 +8162,6 @@ physiological	bodily,sensual,physical,animal
 mechanisms	structure,system,agency,utensils,machines,operation,instruments,tools,process,procedure,appliances,devices,tool,implements,instrument,technique,apparatus
 scoop	spoon,remove,dig,lift
 maintain	renew,control,defend,conserve,protect,hold,finance,declare,preserve,advocate,save,insist,say,retain,manage,keep,sustain,provide,emphasize,restore,stress,support,continue
-augustus	
 respects	compliment,congratulations,substance,blessing,content,greetings,praise,regards
 syndrome	pattern,problem,cycle,development,sickness,complex,disorder
 poor	low,miserable,unfortunate,weak,inferior,modest,insufficient,needy,broke,disadvantaged,pathetic,deprived,impaired,depressed,ordinary
@@ -8647,14 +8176,11 @@ specialized	expert,specific,limited,specialised,special,exclusive,professional,u
 hello	salute,greeting,hi,welcome
 inst	present
 containing	bearing,full,holding,sweeping,extensive,exhaustive,complete,global,overall,thorough,housing,broad
-aa	
 renewed	new,newborn
 ay	boo,rats,aw,ow,alas
-flexibility	
 brewery	plant,works
 according	agreeing,corresponding,consisting,comparable,matching,equivalent,fitting,identical,checking,sorting,conforming,balanced,answering,going
 hats	helmets,caps,hoods
-retriever	
 hint	imply,clue,indication,warning,suspicion,advise,trace,announcement,convey,evidence,intimate,mention,taste,touch,reference,information,reminder,suggest,remind,symptom,implication,whisper,wink,lead,inform,glimpse,sign,notion,idea,suggestion,scent,advice,impression,cue
 wow	yahoo,riot,gee,gag,laugh,hey,ha,entertain,joke,scream,glory,charm
 petitioner	solicitor,applicant
@@ -8681,7 +8207,6 @@ saudi	arab,arabian
 borrowers	embrace,use,copy,adopt,follow,utilize,incorporate
 healthcare	attention,care,aid
 petitions	cries,applications,appeals,prayers,demands,desires,suits
-chess	
 inns	motels,lodges,hostels,campgrounds,hotels
 cornerstone	explanation,keystone,base,theory,pillar,premise,support,basis,assumption,foundation,core,root,ground,framework,essential,justification
 goblet	crystal,bottle,cup,jar,drink,mug,glass,bowl,porcelain,urn
@@ -8692,7 +8217,6 @@ coding	decoding,encoding,cryptography,writing
 investigators	cabinet,researchers,bureau,jury,panel,board,commission,chamber
 nightlife	recreation,performance,diversion,relaxation,enjoyment,amusement,joy,production,entertainment
 schematic	conventional,formal
-introductions	
 pollutants	defects,pollution,poison,contaminants
 steer	marshal,control,conn,pilot,crab,channel,govern,sheer,navigate,herd,tree,dock,direct,usher,drive,route,marshall,head,park,shepherd,command,show,guide,lead,accompany,conduct,corner,helm
 murdered	executed,got,dispatched,killed,terminated,destroyed
@@ -8731,7 +8255,6 @@ poland	oder,warsaw,pole,europe
 finally	soon,last,someday,sometime,completely,shortly,permanently,already,ultimately,certainly,eventually,yet,subsequently,definitely
 synchronized	happened,accompanied,attended,synchronous
 pool	lake,mere,pot,well,bath,tank,lagoon,basin,excavation,group,pond
-billion	
 blog	history,commentaries,chronicle,documentation,record,report,narrative,site,tale,journal,annals,memoir,story,witness,chronology,diary,version,log,commentary,testimony
 equestrian	rider,jockey,buster
 exercising	application,force,using,recruitment,affair,test,operation,effort,hiring,trade,stretching,work,usage,movement,action,drill,function,utilizing,study,enrollment,training,yoga,procedure,performance,task,examination,business,exercise,problem,applying,workout,lesson,enterprise,act,deal,job,use,employing,utilization,set,agency,sweat,process,contracting,trip,bodybuilding,stretch,activity,handling,service,transaction
@@ -8748,7 +8271,6 @@ coolers	tanks,cans,prisons,joints,cages,pens
 wound	harm,injury,slash,shock,slice,pain,trauma,bite,scratch,score,hurt,hit,grief,fracture,cut,damage
 pierce	enter,pick,access
 risen	extended,soar,multiply,come,grow,occur,double,happen,rounded,surge,begin,puffy,expand,advance,lift,convex,accelerate,develop,go,enlarged,raise,climb,swell,expanded,rocket,build,emerge,improve
-fife	
 indeed	likely,possibly,so,absolutely,perhaps,obviously,very,surely,really,naturally,sure,probably,certainly,truly,clearly,undoubtedly,easily,definitely
 chairs	moderators,speakers,presidents
 parse	view,explore,scan,try,research,study,review,consider,vet,screen,observe,analyse,survey,interpret,investigate,determine,check,examine,define,read,inspect,analyze,notice,audit,resolve,translate,probe
@@ -8794,7 +8316,6 @@ massage	treatment,honey,woo,intervention,pat,stroke,praise,compliment,romance,pu
 autos	buses,limousines,machines,automobiles,cars,motors,wheels
 pep	sap,muscle,dash,beans,energy,bounce,juice,gas,punch,drive,life,vinegar,spirit,power,strength,starch,zip,go,ginger,vitality
 drawer	cabinet,lock,bureau,buffet,cavity,compartment,desk,locker,recess,hollow,box,counter,niche,chest,dresser
-pms	
 brand	logo,character,symbol,label,variety,trademark,name,quality
 exists	lives,happen,is,continues,survive,continue,dwell,rules,reside,lie,stay,remain,occur,stand,prevail,live,endure
 guilt	responsibility,status,sadness,regret,sin,liability,grief,shame,condition,sorrow
@@ -8815,7 +8336,6 @@ meaning	indication,sense,significance,import,burden,understanding,message,defini
 lawrence	ks,kansas
 plat	graph,plan,land,lot,print,piece,picture,portion,design,strip,section,estate,property,spike,bit,strap,sketch,lace,field,acreage,parcel,chunk,stripe,map,table,drawing,mix,part,stretch,tract,ground,area,blueprint,outline,plot
 accurately	literally,verbatim,precisely,exactly,directly
-wilde	
 expectations	intention,promise,chance,hope,likelihood,prediction,view,notion,forecast,assumption,confidence,outlook,trust,prospect,prospects,possibility,fear
 shifting	stir,variation,abnormal,changing,migration,operation,irregular,stirring,unstable,evolution,intermittent,limited,movement,occasional,action,confused,transformation,complicated,periodic,incompatible,inappropriate,operating,effective,disturbed,deviation,bizarre,tense,reorganization,unpredictable,exercise,interim,differing,temporary,shift,flow,wandering,unusual,act,seasonal,renewal,volatile,weird,alteration,development,relocation,transfer,conversion,move,recurring,restless,arbitrary,rocky,change,motion,stray,brief,alive,troubled,recurrent,varying,uncertain,flexible,provisional,inconsistent,progress
 pair	partnership,companion,twin,marry,combine,couple,twain,duo,match,combination,two,brace,mate,team
@@ -8878,8 +8398,6 @@ boycott	exclude,reject,black,refuse,avoid
 cashier	release,banker,sack,terminate,ax,teller,remove,axe,fire,accountant,retire,clerk,discharge,can,dismiss
 with	through
 alter	plump,even,charge,land,loose,boil,colour,fix,proof,sauce,draw,blunt,spike,refine,inform,temper,mature,shift,put,ready,tender,disable,clear,merge,drop,age,equal,reverse,alien,warm,customize,validate,shape,blind,break,round,reform,sober,muddy,refresh,moderate,replace,cloud,freeze,cry,chill,market,fill,convert,shallow,parallel,modify,clean,unite,still,prepare,turn,camp,dull,impact,revise,cut,port,excite,fat,grace,lower,soil,patent,contribute,cook,develop,spice,restore,elaborate,exchange,relax,blur,increase,simplify,mix,wake,concentrate,veil,compensate,think,wet,barb,adjust,undo,make,disorder,end,switch,hide,recommend,cool,ash,empty,expand,string,bring,lace,stain,interchange,check,decorate,set,remake,antique,nick,activate,legitimate,chord,change,damage,crush,speed,clarify,terminate,crack,personalize,better,automate,transform,bubble,strengthen,suspend,commute,dismiss,enable,get,substitute,customise,lend,obscure,right,amend,contract,edit,dry,dirty,delay,heat,tense,vary,color,void,corrupt,shake,touch,lift,mark,decrease,shade,capture,add,accelerate,correct,poison,humble,ornament,raise,form,affect,extend,full,translate,match,improve
-clarinet	
-robert	
 alarm	suspense,warning,cry,disturbance,fear,whistle,distress,caution,horror,concern,terror,signal,worry,anxiety,alert,dread,uncertainty,panic,surprise,tension,scare
 operates	explore,handle,work,serve,uses,promote,engage,do,take,keep,runs,run,drive,act,achieve,set,handles,move,transport,works,play,administer,conduct,complete,drives,produce
 exploring	examining,researching,investigating,probing,scanning,studying,viewing
@@ -8903,8 +8421,6 @@ situated	positioned,put,deposited,set,stuck,placed,located,established,planted,l
 ensuring	insure,provide,establish,safeguard,secure,securing,assure,protect
 sworn	enthusiastic,avid,passionate,reliable,serious,intent,committed,faithful,dependable,determined,loyal,tried,confirmed,responsible
 coal	carbon,c
-tyson	
-bulgarian	
 wire	coil,thread,lace,strand,cable,rope,cord,string,line
 micro	baby,microscopic,little,petite,mini,compact,portable,pocket,tiny,small,wee,atomic,miniature,minute,dwarf,model
 aba	textile,material,fabric
@@ -8912,9 +8428,7 @@ failures	breakdown,deterioration,crashes,defeat,decline,loss,collapse,bankruptcy
 pneumatic	built,plump,stacked,round
 universities	academy,school,institution
 compares	refers,links,connects,relates
-ramp	
 frames	figures,architectures,structures,configurations,shells,frameworks,fabrics,shapes
-jonathan	
 disturbance	stir,row,hurry,fun,disorder,trouble,coil,storm,confusion,zoo,hassle,interruption,clutter,noise,disruption,riot,shock,hurricane,activity,explosion,bother,violence
 three	cardinal,iii
 lymphoma	carcinoma,cancer,melanoma,tumor
@@ -8923,7 +8437,6 @@ quarterly	yearly,weekly,monthly,serial,daily,annual,series
 travel	sightseeing,voyage,vacation,tour,cross,transmit,driving,wander,movement,walk,trek,navigate,carry,sailing,flying,transit,visit,drive,cruise,move,migrate,sail,proceed,ride,go,trip,navigation,excursion,journey,fly
 granting	license,leave,compromise,concession,understanding,warrant,accreditation,licence,allowance,clearance,permission,mediation,permit,arrangement,authorization,consent,accord,sanction,signature,compliance,reconciliation
 autonomy	liberty,option,accord,will,independence,freedom,sovereignty,choice
-sirius	
 converting	apply,save,switch,bring,modify,transform,turn,lead,influencing,move,translate,download
 bright	sleek,smart,lucent,flaming,flashing,pleasant,light,mild,colorful,excellent,deep,radiant,brightness,intense,lively,silky,rich,silver,splendid,happy,shining,glowing,clear,fresh,sparkling,glorious,shiny,polished,burning,sunny,brilliant,sharp,slick,fiery,vivid,glossy,golden,good
 shoes	pump,perspective,angle,mind,interpretation,take,place,view,outlook,position,boot,opinion,standpoint,viewpoint
@@ -8945,7 +8458,6 @@ workshops	factory,plants,mills,factories,laboratory,mill,plant,shops,seminar,stu
 breathtaking	stunning,inspiring,amazing,interesting,impressive,magnificent,electric,intriguing,fascinating,exciting
 father	daddy,pa,ancestor,parent,dad,pop,predecessor,papa
 newfoundland	dog
-ng	
 contributor	patron,helper,supporter,protector,angel,subscriber,donor,author
 ambitious	earnest,pushing,energetic,enthusiastic,motivated,ambition,dynamic,aggressive,bold,impressive,difficult,demanding,challenging,determined,visionary,driven,eager
 earned	accepted,captured,secured,achieved,made,realized,proper,landed,got,acknowledged,drew,anticipated,expected,collected,obtained,carried,seized,attained,won,acquired,gained
@@ -9019,7 +8531,6 @@ invaluable	valuable,helpful,precious
 forwarded	assisted,cultivated,backed,supported,encouraged,promoted,endorsed,advanced
 gauge	criterion,guess,suppose,judge,meter,make,evaluate,weigh,benchmark,figure,estimate,approximate,count,compute,indicator,determine,put,set,ascertain,calculate,understand,give,place,assess,pattern
 introduce	send,offer,organize,plan,admit,submit,suggest,launch,announce,ship,import,meet,recommend,inform,start,initiate,greet,propose,establish,address,install,include,present,open,found
-octave	
 breaking	crack,smashing,cracking,splitting,chip,destroying,break,reducing,fracture
 draw	get,select,ink,make,picture,pencil,carry,collect,take,paint,sketch,bring,gather,mark,drag,write,cartoon,pick,attract,choose,invite,outline,prompt
 donated	nominal,unpaid,complimentary,discretionary,optional,free,given,gratis,voluntary
@@ -9036,7 +8547,6 @@ week	future,space,date,weekend,season,stage,era,second,turn,moment,rag,period,li
 retrieving	save,fetch,salvage,repair,recovering,rescue,recover,restore
 until	till
 infrastructure	frame,architecture,water,skeleton,base,configuration,main,structure,shell,transit,network,framing,grid,framework,stock,fabric,fund,store
-spam	
 touching	joining,stirring,linked,neighboring,united,pathetic,affecting,nearest,flush,closest,surrounding,close,stunning,connecting,adjoining,adjacent,communicating,sad,connected,contiguous,attached,near
 blackberry	berry
 cemetery	tomb,site,garden
@@ -9057,7 +8567,6 @@ prejudice	harm,discrimination,injustice,poison,ply,undermine,taboo,racism,favor,
 thesaurus	glossary,vocabulary,dictionary
 perfect	accomplish,seamless,simple,improve,best,clean,prime,excellent,perfection,proper,refine,exquisite,ideal,exact,cold,splendid,absolute,exceptional,clear,classic,pure,realize,precise,develop,polished,appropriate,down,exemplary,terrific,ultimate,superb,great,complete,full,true,model,suitable,mint
 types	brand,varieties,lot,sorts,genres,strain,variety,sort,manners,character,category,copy,kinds,classes,write,breed,breeds,number,likes,stripes,description,standard,form,sample,nature,pattern,group,species,descriptions
-argus	
 story	history,fable,fantasy,comedy,autobiography,myth,fiction,message,substance,information,record,drama,report,article,yarn,narrative,tale,content,novel,memoir,feature,biography,adventure,legend,version,description,tragedy,book
 mc	dj,khz,rate,mhz,host,kc
 lebanon	sur,beirut,tyre,asia
@@ -9155,7 +8664,6 @@ custody	jail,arrest,management,control,care,hold,trust,keeping,ward,imprisonment
 defaults	slides,fails
 prospect	aspect,perspective,scenery,anticipation,likelihood,chance,view,thought,landscape,outlook,hope,panorama,probability,potential,possibility,plan,expectation,vision,vista,forecast,promise,future,proposal
 rainforest	woods,forest,wood
-anemia	
 parrot	amazon,repeat,echo,quote,bird,mouth,poll
 organizers	commanders,managers,makers,leaders,producers,directors,developer,designer,coordinator,handlers,builders,planners,generators,promoter,architects,engineers,pioneers,designers,developers
 measuring	observation,estimating,scaling,sounding,reading,spanning,surveying,weighing,determining,measure,activity,calculating,evaluating,measurement,plumbing,sampling,assessing
@@ -9167,7 +8675,6 @@ terrorists	menace,terror,sword,pressure,violence,threat,fear
 scattered	disconnected,intermittent,distributed,arbitrary,random,dispersed,lucky,occasional,contingent,isolated,casual,stray,accidental,odd
 giants	titan,elephants,titans,dinosaurs,monsters,elephant,whales
 toys	plays,fool,jokes,doll,fiddle,delights,sports,flirt,tease
-au	
 weddings	matches,marriages
 guests	inmate,companion,tenant,recipient,client,visitors,caller,customer,patron,visitor
 account	witness,annals,check,statement,chronicle,charge,narrative,memoir,saga,story,bill,log,version,diary,chronology,detail,explanation,documentation,book,commentaries,record,report,tale,history,testimony,life,commentary,biography
@@ -9180,14 +8687,12 @@ latin	italic,romance
 noise	whisper,cry,thunder,cracking,clash,explosion,splash,crash,slam,rumble,scratch,chatter,hum,boom,buzz,turbulence,snap,blast,bark,scream,plump,bam,din,crunch,screaming,grinding,crack,report,pant,bang,sound
 commissioned	assigned,appointed,legitimate,nominated,designated,authorized,authorised,licensed,accredited,recognized,delegated,certified,lawful
 network	screen,mesh,system,chain,screening,lace,net,structure,grid,web,organization
-goth	
 armenia	armenian,cis
 puppets	dolls
 kindness	service,sympathy,waiver,goodness,indulgence,grace,hospitality,courtesy,benefit,tolerance,privilege,patience,understanding,affection,humanity,blessing,favor,generosity,mercy,advantage,turn
 chance	hearing,odds,shot,throw,likelihood,hit,luck,outlook,possibility,lot,hazard,opportunity,outcome,day,room,time,prospect,say,opening,break,circumstance,street,crack,risk,accident,future,audience,advantage,occasion
 bats	strange,ballistic,off,foolish,wacky,insane,cracked,mental,disturbed,mad,nuts,depressed,crazy,obsessed,paranoid,crackers,psycho,queer,buggy,odd
 charmed	magic,delighted,possessed,magical,cursed,enchanted,fairy
-hypertext	
 standing	quality,rating,prestige,place,fashion,rank,importance,status,ranking,dignity,state,class,honor,position,reputation
 brakes	woodlands,brake,forests,brushes,woods
 scion	seed,child,successor,offspring
@@ -9217,7 +8722,6 @@ plaza	park,yard,court,place,enclosure,close,square,courtyard,deck,terrace,quad,p
 matters	business,province,ideas,system,topics,subjects,commerce,themes,questions,problems,purposes,realm,motives,area,contents,field,issues,trade,life,sale
 gam	wing,stem,arm,branch,wheel,leg
 painted	represented,decorated,drawn,composed,designed,illustrated,covered,photographic,stained,video,graphical,finished
-valium	
 uncle	cousin,sibling,father,fellow,person,gentleman,mother,guy,dude,folk,aunt
 inflammatory	revolutionary,medication,medicine
 sweden	ec,europe,eu,scandinavia,stockholm
@@ -9238,7 +8742,6 @@ goto	use,consult
 soybean	soy,bean
 siding	running,turnout,joining,tying,sorting,railroad,wedding,travelling,relating,linking,mixing,grouping,railway,connecting,coupling,covering,bonding,traveling
 vanguard	van,pioneer,underground
-beanie	
 enthusiasts	experts,addict,lover,fan,fools,nuts,lovers,supporter,participant,friends,buff,freaks,bugs,fans,supporters,collectors,believer
 opportunity	hearing,shot,freedom,throw,chance,convenience,excuse,hope,possibility,moment,day,room,time,event,say,opening,space,street,crack,audience,occasion
 harper	musician
@@ -9250,25 +8753,20 @@ races	tribes,competition,hurry,contention,dart,blood,tear,compete,bolt,relay,cha
 scarlet	coral,glowing,cardinal,ruby,crimson,red,maroon,flaming,wine,cherry,rose
 representing	describing,identifying,defining
 bland	delicate,soothing,smooth,tender,mild,peaceful,calm,pleasant,boring,benign,soft,gentle,light,easy,dull,flat,quiet
-institutional	
 mags	books,journals,magazines,papers,newsletters,serials,newspapers,bulletins,periodicals,editions,organs,reviews
 la	metal
 kt	carat,unit
-hercules	
 creativity	ability,power,innovation,creative,talent,productivity,conception,vision,design,flight,imagination,invention
 bills	documents,rates,receipts,records,accounts,statements,costs,invoices,fees,prices,expenses,checks,tabs
 keep	check,retain,remember,put,perform,celebrate,enjoy,block,protect,delay,bless,place,have,sustain,observe,control,hold,store,preserve,conduct,save,continue,operate,run,conserve,manage,maintain,limit,carry,distance,stop,support
 kingston	hull
-seychelles	
 duke	fist,shah,master,marquis,count,sheikh,emperor,knight,lord,grip,don,palm,monarch,earl,king,baron,prince
-amos	
 laundry	garment,wash,washing
 helping	portion,taste,slice,wing,meal,serving,piece,computerized,drink,oyster,breast,round
 skirts	lips,rims,boundaries,margins,frames,bounds,borders,edges,ends
 establishes	base,install,confirms,put,start,demonstrates,institute,formulate,proves,confirm,make,shows,form,found,settle,build,determine,create,authorize,prove,provide
 caution	attention,advise,warn,inform,urge,care,wake,alert,discretion
 wholly	entire,all,well,altogether,full,completely,utterly,specifically,dead,absolutely,solely,entirely,wide,clean,fast,thoroughly,totally,quite,enough,flat,even,purely,fully,out,basically,individually,exactly,whole,perfectly
-beta	
 solid	steady,satisfying,tight,informed,powder,credible,hard,glass,justified,true,decent,real,sturdy,genuine,just,crystal,stable,strong,firm,good,rational,satisfactory,matter,reasonable,serious,sensible,logical,substantial,plausible,plastic,sober,actual,valid,food
 conduct	keep,deal,oversight,charge,lead,protect,guide,administer,oversee,management,control,care,manipulation,order,handle,stance,organize,plan,attend,handling,operate,strategy,run,direct,manage,tend,policy,attitude,supervise,transaction,regulate,manner,show,treatment,send,steer,govern
 publicity	fame,commercial,publication,billboard,marketing,ad,packaging,substance,propaganda,distribution,content,pr,advertising,advert,attention,promotion,hype,plug,pitch,endorsement,message,noise,advertisement,poster
@@ -9309,7 +8807,6 @@ arcadia	eden,nirvana,joy,utopia,sion,zion,paradise,bliss,heaven,wonderland,greec
 blessings	consent,backing,dedication,kindness,gift,miracle,petitions,grace,asset,permission,prayers
 humidity	moisture,damp
 hoop	rim,barrel,band,loop,ring,circle,tyre,belt,collar,eye,basket,round,coil
-benjamin	
 enjoyment	amusement,possession,luxury,relaxation,joy,thrill,ownership,control,keeping,recreation,happiness,fun,indulgence,satisfaction,hands,pleasure
 portage	transmission,travel,transfer,transport,bring,transit,bear,move,lift,haul,shipping,tote,pack,track,remove,distribution,take,lug,transmit,shipment,import,carry,ferry,give,passage
 lyrics	songs,poems,verses
@@ -9344,7 +8841,6 @@ transforming	transfer,mold,adjusting,remodeling,alter,modifying,convert,altering
 tick	instant,wink,beat,stretch,minute,bit,wire,while,threshold,moment,point,nick,second,spell,flash,heartbeat,crack,shake,sound
 screened	preferred,picked,chosen,selected,exclusive
 priest	elder,monk,divine,clerical,preacher,reverend,minister,father,missionary,bishop,pope,pastor,canon,order,lama,archbishop,clerk
-ae	
 central	big,chief,highest,cardinal,significant,important,dominant,fundamental,principal,first,supreme,key,greatest,foremost,prior,great,main,paramount,sovereign,essential,leading,capital,primary,basic,premier
 www	web
 stuff	expertise,ability,emission,foam,things,paper,atom,rock,material,fill,fiber,credentials,facility,earth,mineral,dust,litter,meat,adhesive,competence,capacity,gear,pack,particulate,ammunition,stone,substance,junk,talent,qualification,color,precursor,capability,aggregate,particle,discharge,cloth,conductor,ground,matter,squeeze,fibre,waste,toner,molecule,equipment,packing,chemical,wedge,bedding,staple,filling,gift,goods,builder,colour,contamination,pad
@@ -9365,7 +8861,6 @@ bangladesh	asia
 brewers	promote,pick,encourage,raise,trigger,stimulate
 interface	league,connect,tell,accommodate,relationship,broadcast,network,element,transfer,relate,participate,crossing,reveal,exchange,combine,mix,intersection,write,inform,merge,visit,coordinate,absorb,phone,attach,convey,telephone,fuse,suggest,interview,terminal,approach,ally,channel,couple,associate,cooperate,consult,organize,blend,incorporate,interact,consolidate,reach,link,conform,identify,affiliate,advertise,correspond,collaborate,join,call,association,mesh,transmit,unite,argue,bind,negotiate,contact,tie,talk,communication,disclose
 authorities	bureaucracy,governance,regime,division,government,hands,professionals,legislature,palace,enthusiasts,experts,organisation,specialists,organization,judiciary,scholars,consultants,empire,wizards,court,establishment,masters,executive,artists,bench,administration,brass,state
-tai	
 pick	open,elect,cut,nominee,hit,choice,option,selection,favorite,chosen,prize,prefer,select,bet,choose,draw,candidate,take,pull,name
 proportional	balanced,comparable,symmetric,relative,corresponding,reciprocal
 lightly	smoothly,easily,softly,easy,quietly,well,simply,freely,slightly,readily,moderately,efficiently
@@ -9382,7 +8877,6 @@ expensive	premium,steep,dear,luxurious,valuable,high,fancy,costly,precious,upsca
 flowers	buds,blooms,flora
 loader	pile,freight,lumber,laden,saddle,weigh,fill,attendant,heap,weight,pack,stack,burden
 guidebook	text,map,book,guide,novel,tome,paper,dictionary,manual,paperback,hardback,hardcover,itinerary,catalogue,handbook,encyclopedia,catalog
-hb	
 mormon	protestant
 girls	daughter,she,sisters,adolescent,birds,schoolgirl,misses,virgins,lady,teenager
 lake	laguna,reservoir,lagoon,recess,basin,pond,water,loch,floor,inlet,pool
@@ -9398,7 +8892,6 @@ argentine	slate,silver,argentine,dirty,chocolate,neutral,pewter,gray,white,sandy
 implemented	supplied,executed,dressed,furnished,enforced,administered,applied,armed
 cell	compartment,chamber,room,apartment,unit,closet,egg,cabin,cage
 sunday	amateur,backyard,weekend
-uruguay	
 female	feminine,creature,girl,fauna,dam,animal,beast,mother,hen
 mediated	treated,studied
 alignment	pattern,orientation,disposal,disposition,system,sequence,distribution,arrangement,setup,structure,continuity,true,order,layout,design,ordering
@@ -9420,7 +8913,6 @@ burma	asean,myanmar
 construed	define,parse,presumed,implied,interpreted,interpret,translate
 nirvana	innocence,ignorance,blindness
 hunter	fowler,tracker,archer
-parker	
 raw	natural,organic,crude,rare,bitter,wet,basic,coarse,rude,cold,fresh,rough
 marry	connect,unite,mate,wed,join,match
 fuse	connect,couple,melt,unite,blend,alloy,join,merge,combine,weld,integrate,absorb,flux,marry,mix,gauge
@@ -9436,7 +8928,6 @@ controlling	protective,jealous,demanding
 mobility	quality,migration,movement,shifting,motion,move,relocation,shift,flexibility,stirring
 statutes	laws,ordinances,amendments,acts,regulations,bills
 acme	noon,summit,apex,zenith,climax,crown,sum,vertex,pinnacle,meridian,crest,peak,height,top,extreme
-miller	
 immediately	quickly,directly,now,rapidly,soon,away,promptly,right,presently,shortly,bang,instantly,suddenly
 britain	nato,ec,europe,scotland,cymru,wales,england,uk
 growth	carcinoma,gain,growing,rise,culture,cultivation,increase,expansion,lump,vegetation,improvement,advancement,development,production,flowering,hike,proliferation,prosperity,tumor,suppression,advance,success,surge,habit
@@ -9504,9 +8995,7 @@ wrote	tell,composed,print,sign,address,rewrite,authored,pen,typed,compose,note,r
 foundation	institution,group,endowment,infrastructure,establishment,base,ground,support,association,corporation,company,authority,institute,relation,organization,charity,enterprise,society
 informal	unauthorized,daily,relaxed,unofficial,everyday,familiar,casual,irregular
 stew	sweat,boil,panic,cook,pie,soup,brew
-drosophila	
 wherever	point,location,place,where,home,scene,section,situation,site,slot,spot,station,ground,setting,position
-splitter	
 initials	authors,registers,inks,signs,pens,stamp,brand,label,autographs
 cattle	bovine,welsh,bos,trash,devon,calf,cow,mob,commons,ox,public,cows,bull,mass,crowd,herd,multitude,grade,millions,bullock,steer,people,beef
 enforce	invoke,require,impose,administer,accomplish,reinforce,sanction,fulfill,apply,run,execute,implement,fulfil
@@ -9516,7 +9005,6 @@ sting	stick,surcharge,cheat,soak,clip,inspire,bite,hurting,hurt,fleece,skin
 cities	towns,suburbs,place,municipality,metropolis,center,capital,downtown,port,municipalities
 indicative	reflective,significant,symbolic,referring,mode,characteristic
 decals	stamps,plaques,logos,brands,markers,labels,symbols,badges,marks,trademarks,stickers,seals
-fairies	
 neurology	medicine
 musicals	dramas,comedies,opera,works
 amended	transformed,helped,corrected,upgraded,improved,revised,enhanced,modified,refined,cooked,updated,adjusted,enriched
@@ -9529,7 +9017,6 @@ acclaimed	accredited,praised,endorsed
 attending	in,turnout,appearance,attendance,presence,participating,present,appearing,available
 ow	boo,ay,aw,pooh,rats
 exemption	defense,privilege,amnesty,immunity,security,freedom,shield,cover,safety,forgiveness,protection,discharge,exception,armor
-jeremiah	
 quoted	cited,copied,mentioned,referenced
 powered	discharged,fired,launched,charged,started,switched,stimulated,drove,moved,ran,triggered,activated,pushed,run,released,generated
 discretionary	elective,voluntary,optional,arbitrary
@@ -9589,8 +9076,6 @@ increase	accumulate,full,further,gain,mount,strengthen,reinforce,increment,rise,
 recruit	rookie,improve,engage,hire,job,trainee,volunteer,draft,enter,select,enroll,raise,employ,fee,soldier,retain,place,register,pay,sailor
 sentences	punish,judgment,verdict,term,decisions,blame,decision,punishment,declarations,order,penalty,holdings,rulings,judgments,jail,findings,ruling
 deserved	earned,justified,legal,just,appropriate,warranted,right,fair,suitable,proper,legitimate,due,competent
-scarface	
-tolkien	
 quickly	quick,immediately,instantly,rapidly,promptly,hot,fast,swift,soon
 cumberland	tn,ky,tennessee
 squadron	cluster,fleet,crew,grouping,battery,cohort,armada,crop,squad,band,organization,brigade,team,battalion,wing,group,batch
@@ -9603,7 +9088,6 @@ comp	create,approval,produce,check,test,offering,construction,assessment,prize,n
 penny	subunit,pound,punt
 corvette	junk,submarine,bark,cutter,vessel,yacht
 telephone	contact,receiver,handset,dial,call,extension,phone
-ipo	
 condo	refuge,nest,duplex,cooperative,condominium,farm,salon,resort,haven,shed,residence,shelter,shack,mansion,palace,sanctuary,headquarters,hut,wing,efficiency,tent,box,building,cabin,flat,townhouse,suite,home,terrain,studio,dorm,hall,house,cottage,safety,apartment,penthouse,cave,trailer,dwelling,surroundings,place,asylum,environment,territory,hospital,lodging,saloon
 url	address,reference
 dimension	measure,extent,bulk,width,thickness,size,length,measurement,proportion,importance,time,range,height,quality,scope,magnitude,element,aspect,breadth,area
@@ -9648,7 +9132,6 @@ substantially	mostly,altogether,materially,essentially,most,largely,really,virtu
 suit	conform,prosecution,satisfy,action,lawsuit,application,enhance,petition,trial,proceeding,serve,correspond,become,uniform,modify,litigation,costume,garment,wardrobe,case,court,please,ensemble,fit,adjust,accommodate,complaint,dress
 warp	prop,theory,cornerstone,framework,bottom,corrupt,core,keystone,focus,base,justification,premise,ground,basis,root,foundation,support
 includes	enter,carry,incorporate,numbers,carries,comprises,comprise,build,hold,involves,cover,receive,have,add,introduce,encompasses,contains,combine
-copiers	
 committee	delegation,chamber,commission,pac,panel,mission,board,subcommittee,jury,bureau,cabinet
 lattice	framework,shape,fabric,outline,structure,system,organisation,contour,skeleton,chassis,organization,infrastructure,framing,architecture,shell,frame,silhouette,cage,configuration,profile,network
 sidewalk	pavement,track,paving,walk,path
@@ -9660,7 +9143,6 @@ bis	repeatedly,over
 swim	move,reel,travel,glide,turn,float,fin,go,crawl,dive,spin,paddle,wade,school
 ana	album,accumulation,digest,collection,symposium,compilation,garland,reader,almanac,anthology
 laos	lao,asean
-diaper	
 loch	bay,pond,reservoir,arm,gulf,basin,inlet,lagoon,harbor,creek,cove,port,pool
 boost	assist,encourage,increment,rise,sustain,assistance,improvement,support,extend,advance,addition,aid,enlarge,breakthrough,expand,jump,develop,raise,encouragement,expansion,hike,lift,push,promote
 decorating	dressing,exquisite,painting,doing
@@ -9696,7 +9178,6 @@ sofia	bulgaria
 each	respectively,individually,separately,all,any,every
 tourist	visitor,traveller,traveler
 ranch	estate,grange,land,farm,spread,homestead,plantation
-muller	
 sought	pursued
 admits	take,says,tells,talk,reveal,agree,recognize,affirm,reveals,approve,announces,grant,receive,declares,disclose,allow,enter,confirm,confirms,introduce,indicate,allows,grants,tell,accept,declare,permit,sign,agrees,acknowledges,recognizes,accepts
 depletion	loss,decline,decrease,abatement,dent,reduction,expenditure,consumption,depression,deficiency,drop
@@ -9714,7 +9195,6 @@ forgive	justify,release,excuse,ignore,forget,yield,free,redeem,pardon
 graceful	liquid,light,slender,delicate,handsome,neat,flexible,refined,beautiful,exquisite,decorative,elegant,athletic,smooth,agile,fluid
 gene	factor,dna,chromosome,sequence
 leadership	government,navigation,administration,direction,supervision,running,coaching,policing,helm,governance,guidance,encouragement,care,control,steering,initiative,activity,lead,management,stewardship
-meg	
 spelling	letter,attracting,charming,striking,overlooking
 gag	scream,rib,parody,nifty,humor,sally,wow,wit,funny,humour,riot,laugh,joke,trick,suppress
 pans	appearances,looks,faces,features,mugs
@@ -9747,9 +9227,7 @@ unlimited	vast,unrestricted,absolute,immense,infinite,oceanic,universal,endless
 destinations	rankings,terminal,haven,places,offices,jobs,spots,gigs,placements,stations,nominations,situations,harbor,assignments,elections,choices,target,positions,selections,station,commissions,stop
 einstein	intellect,brain,genius,intellectual
 welfare	happiness,health,joy,benefit,sake,success,good,aid,progress,prosperity,fitness,relief,interest,wellness
-unesco	
 lexicon	cognition,language,dictionary,vocabulary,speech,knowledge
-joel	
 witnesses	public,proofs,gathering,gallery,documents,testimonials,market,congregation,vouchers,crowd
 boarding	enter,waiting,accommodate,sustaining,serving,feeding,going,provisioning,leaving,departure,dining,catering,catch
 rumor	gossip,whisper,noise,comment,news,buzz,word,story,fabrication,tale,dish,scandal,report,talk,lie,suggestion
@@ -9767,7 +9245,6 @@ limousine	truck,car,compact,automobile,transportation,taxi,pickup,mini,wheels,ri
 begun	commenced,created,opened,started,launched
 conducting	government,administrative,managing,administration,authority,supervising,guiding,agency,keeping,performing,rule,running,organization,controlling,legislation,watching,protecting,policy,ruling,handling,operating,control,leading,dominant,directing,overlooking,administering,governing,regulating
 wealthy	privileged,upscale,successful,independent,loaded,comfortable,rich
-portuguese	
 alcoholism	mania,addiction,passion
 jubilee	gala,vacation,fiesta,joy,competition,celebration,recess,fair,holiday,pride,performance,bash,triumph,feast,festival,carnival,anniversary,ceremony,birthday,party,break
 honor	acclaim,praise,confidence,credit,fame,faith,reputation,pledge,fairness,acknowledge,recognize,distinction,trust,morality,observe,courage,tribute,celebration,admire,appreciate,respect,pleasure,privilege,toast,salute,dignity,glory,attention,recognise,recognition,worship,compliment,prestige,favor,decorate,virtue,drink,honesty,esteem,celebrate,thank,reward
@@ -9781,16 +9258,13 @@ show	appearance,convey,reach,produce,manifest,film,demo,note,parade,production,p
 strokes	trophy,pounds,swings,citation,approval,premium,scholarship,praise,boxes,medal,credit,clips,bats,socks,bounty,remuneration,stripes,honor,title,applause,hits,purse,beats,acceptance,gratitude,benefit,recognition,attention,knees,gold,compensation,cracks,picks,blows,award,belts,dividend,advantage,rave,bonus,championship,hacks,esteem,profit,switches,jackpot,hands,kicks,hooks,crown,reward
 deletion	elimination,censorship,omission,removal,skip
 crashing	deadly,absolute,very,clean,pure,rank,eternal,huge,simple,genuine,endless,perfect,blank,utter,outright,thorough,dead,stone,bloody,definite,fair,flaming,constant,damn,stark,flat,terrible,complete,regular,perpetual,real,damned,total,sheer,profound,horrible
-snorkeling	
 accounted	considered,believed,alleged,supposed,felt,called,rated,counted,putative,regarded,assumed,deemed,held,viewed,thought
 breastfeeding	nursing
 filings	instruments,blanks,papers,documents,forms,sheets
 tends	manage,feed,protect,do,go,trends,goes,indicates,bear,lean,influence,favor,keep,suggests,turn,contribute,maintain,runs,watch
-andorra	
 gatherings	panels,assemblies,audiences,crowds,conferences,meetings
 retrieval	rescue,reclamation,memory,recovery
 integers	figures,digits,numbers
-blinds	
 tennis	advantage,return,singles,doubles
 lesson	study,test,class,instruction,assignment,practice,exercise,message,education,task,warning,reading,homework,lecture,teaching
 filming	take,photograph,animation,imaging,shoot
@@ -9807,13 +9281,11 @@ newbie	beginner,apprentice,virgin,rookie,starter,student,novice,recruit,freshman
 objective	aim,business,thing,design,detached,idea,equitable,point,unbiased,ambition,meaning,intent,plan,dream,ideal,goal,target,intention,object,end,purpose
 graphical	graphic,figure,diagram,caption,art,picture,illustration,plate,drawing,visual,artwork,image
 proved	verified,evidenced,permanent,established,decisive,developed,demonstrated,settled,final,tried,advanced,tested,proven
-tablespoons	
 advances	further,gain,encourage,rise,growth,development,improve,offer,loans,progress,step,advancement,storm,breakthrough,benefit,achieve,develop,grow,increase,introduce,speed,grants,boost,raise,accelerate,upgrade,gives,hike,push,promote
 nightclub	club,disco,cafe,cabaret,tavern,bistro,bar,saloon,restaurant,pub
 levels	rankings,fell,ranks,standings,wreck,places,drop,ruin,grade,status,achievement,stations,reaches,situations,standard,degree,stage,positions,degrees,conditions
 talents	eyes,thing,flair,expertise,power,skill,gift,savvy,art,genius,capacity,ears,skills,capability,gifts,faculties
 victorian	moral,refined,proper
-keno	
 widow	madam,spouse,lady,partner,companion,wife,housewife,woman
 tunnel	gallery,hollow,cave,mine,channel,pit,subway,hole,shaft,excavation,bunker
 fats	society,pride,choice,pick,cream,elect,royalty,pink,top,prime,establishment,elite,flower,best,flesh,quality,grease
@@ -9824,7 +9296,6 @@ search	quest,research,inspect,check,looking,seek,investigation,hunting,investiga
 impartial	square,neutral,candid,unbiased,just,equal,fair,detached,objective,equitable
 torso	piece,thing,shape,bust,can,waist,back,stomach,cheek,trunk,tail,icon,shoulder,sculpture,stern,marble,posterior,rear,behind,figure,condition,seat,hip,body,image,stem,side,bronze,belly,object,middle,chest,bottom
 threat	menace,danger,risk,trouble,hazard
-ammonia	
 hr	day,minute,min,quarter,hour
 pharmaceutical	cure,antibiotic,medicinal,pill,prescription,remedy,specific,medication,medicine,drug
 sake	ale,whisky,juice,bottle,liquor,spirits,sauce,whiskey,pop,mead,benefit,load,cocktail,chaser,alcohol,brandy,drink,rum,beer,wine,behalf,interest
@@ -9878,9 +9349,7 @@ operational	ready,operating,on,useful,operative,functional,viable,active,functio
 removed	apart,isolated,retired,deep,disconnected,remote,away,far,distant,detached
 reports	taps,testimony,evidence,goods,crashes,input,cracks,pops,picture,statistics,knowledge,info
 glen	dale,dell,gill,hollow,saddle,canyon,gap,valley,pass,gorge,col,linn,vale
-kennedy	
 gadget	invention,apparatus,convenience,device,innovation,mechanism,implement,object,tool,appliance,instrument,accessory,widget
-paige	
 spoken	oral,expressed,verbal,articulate
 talking	jazz,conversation,articulate,chatter,wind,cant,dialog,speaking,vocal,talk,dialogue
 rove	swan,move,stroll,travel,cast,bat,float,range,go,cruise,stray,roll,err,drift,wander
@@ -9893,7 +9362,6 @@ refusal	veto,reversal,prohibition,rejection,denial,ban,exclusion,nay,no
 agendas	programs,schedule,program,plan,timetable,calendars,organizations,calendar,schedules
 barb	remark,attack,criticism,offence,dart,offense,shot,input,slap,arrow,dis,slight,name,shaft,insult,dig,comment,personality
 trench	gorge,ditch,pit
-jv	
 ashes	residue,ruins,debris,remains,wreck
 sulfate	salt
 comprise	involve,span,include,be,hold,cover,constitute,compose,contain,form
@@ -9910,14 +9378,12 @@ residence	bungalow,roof,pad,shelter,mansion,palace,farmhouse,condo,cabin,home,ha
 soundtrack	audio
 glowing	clear,sparkling,vivid,vibrant,light,fiery,splendid,polished,glow,flaming,shining,flashing,bright,corona,brilliant,radiant,burning,shiny,lucent
 lengthy	extensive,extended,long,large,prolonged
-prefix	
 tenor	tone,core,theme,subject,direction,pivot,root,keynote,point,sum,essence,thesis,proposition,net,drift,kernel,heart,nucleus,content,course,substance,meat,body,hypothesis,mood
 dissertation	essay,thesis,article,commentary
 xiii	xiii
 borrowed	assumed,worn,old
 versions	variant,story,performances,adaptation,tale,history,readings,form,interpretation,interpretations,variations,accounts,report,translation
 tension	discomfort,strain,pressure,stress,concern,anxiety,suspense,worry
-australian	
 boundary	bound,extent,outline,shoreline,limitation,frontier,bounds,barrier,horizon,cap,edge,line,termination,surface,ceiling,limit,end,perimeter,border
 zinc	platinum,gold,metal,iron,mineral
 fort	fortress,garrison,bunker,castle
@@ -10012,11 +9478,9 @@ interstate	internal,avenue,highway,ethnic,bypass,roadway,drive,drag,pass,social,
 sauce	dip,dressing,mole,worcestershire,dish
 sheikh	duke,earl,prince,master,ruler,knight,baron,marquis,don,count,cavalier
 penthouse	addendum,condominium,appendix,wing,annex,suite,addition,increase,cooperative,expansion,flat,condo,delay,extension,development
-jude	
 enrichment	ornament,dressing,improvement,embroidery,glitter,apparel,enhancement,decoration
 repealed	dropped,called,abandoned,cancelled,suspended,terminated,reverse,void,lift,withdraw,revoked,reversed,recalled,cancel,canceled
 rolls	rounds,balls
-photon	
 advertisements	postings,notices,announcements,notifications,bulletins,adverts,reports,brochures,releases,ads
 permit	favour,clear,enable,allow,authorize,concession,stand,have,favor,pass,give,warrant,brook,allowance,stomach,charter,admit,accept,support,permission,patent,grant,suffer,trust,visa,license,boost,let,tolerate,include,sanction,privilege,consent,empower,endorse,bear,digest,legitimate,passport,endure
 generating	creating,yielding,rich,promoting,making,producing,creative,bringing,causing,doing,working
@@ -10026,7 +9490,6 @@ cot	couch,hay,bunk,pad,rack,sofa,pallet,sack,mattress
 mercer	dealer,trader
 control	authority,regulate,oversight,discipline,supervise,power,rule,authorisation,regulator,command,management,dominate,check,mastery,contain,restriction,jurisdiction,government,restraint,limit,administer,govern,run,controller,force,oversee,lead,manage,curb,hold,manipulate,regulation,supervision,adjust,dominance,conduct,handle,leadership
 alien	foreign,stranger,unusual,international,migrant,multicultural,exotic,imported,refugee,introduced,external,immigrant,visitor
-ali	
 badger	bother,bug,devil,insist,hassle,worry,anger,spur,plague,egg,dun,urge,harry,bait,prompt,hound,tease,rag,prod,push
 weapon	steel,arm,lance,brand,instrument,guard,shotgun,armor,arms,ammunition,wmd,sword,sling,cannon,blade,pistol,bow,firearm,missile,spear,rifle,defense,gun,bomb,pike,knife,shield,shaft
 dinnerware	setting,table,service,glassware,china,pottery,tableware,porcelain,cutlery,dinnerware,plate,glass,cup,bowl,ware,crystal
@@ -10036,14 +9499,11 @@ confusion	chaos,distress,turbulence,discomfort,disturbance,maze,complexity,disor
 dinosaurs	fossils
 pinball	game
 sustain	satisfy,fill,see,assist,retain,have,defend,feed,undergo,keep,save,feel,help,nurse,suffer,preserve,tolerate,withstand,continue
-aerobic	
 uncertain	authority,risky,unpredictable,unresolved,volatile,inconsistent,confidence,assurance,questionable,vague,ambiguous,certainty,unstable,variable,unclear,unsure
 sustained	continuous,fed,filled,continued,satisfied,constant
-meteorological	
 replace	succeed,follow,commute,recover,supply,renew,relieve,substitute,exchange,restore,change
 recruited	employed,retained,placed,enlisted,paid,assumed,engaged,hired
 bottle	whiskey,liquor,jar,ale,urn,vessel,brandy,drink,mouth,spirits,sauce,beer,wine,juice,rum,alcohol,gin,vodka,whisky,glass
-kr	
 fps	indie,independence,free,separate,autonomous,individual
 malls	walks
 mindless	opaque,dumb,dull,stupid,silly,unreasonable,crazy,ignorant,soft,dense,foolish,dim,simple,meaningless,insane,slow,mad,thick
@@ -10054,7 +9514,6 @@ infinite	endless,vast,unlimited,immense,eternal,perpetual,absolute,enormous,ever
 pendant	charm,supported,dependent,hanging
 genetic	transmitted,historical,congenital,inherited,inherent
 quietly	privately,quiet,still,secretly
-kappa	
 sinister	lonely,ill,dark,dire,grey,gray,evil,unfortunate,black,threatening
 fairly	relatively,something,properly,pretty,adequately,moderately,reasonably,quite,rather,somewhat,enough,honestly
 fracture	powder,reduce,smash,bust,crack,destroy,split,crush,break,wound,abuse,blast,ruin,fragment
@@ -10078,14 +9537,12 @@ encoding	coding,cryptography,compression
 antenna	sender,transmitter,receiver,wire,aerial
 exercised	efficient,distressed,apt,accomplished,practiced,troubled,talented,disturbed,applied,competent,enforced,skilled,gifted,anxious,capable,used,qualified,trained,employed,proficient,experienced,tested,utilized
 paved	sealed
-patrick	
 wreck	debris,ashes,collapse,smash,trash,crash,destroy,destruction,batter,ruins,sink,hulk,mar,mess,ruin,remains,undermine,residue
 firms	associations,enterprises,establishments,houses,concerns,interests,agencies,companies,businesses,corporations
 water	rinse,hydrogen,flush,soak,dip,h,shower,wet,sweat,damp,saltwater,spray,rain,drink,mist,tear,o,ice,freshwater,flood,oxygen,thin,liquid,wash
 recalled	remembered,reproduced,minded,reminded
 filipino	philippines,aboriginal
 achieving	realizing,ideal,act,logging,evolution,acquiring,capturing,quality,deed,virtue,performance,excellence,getting,making,precision,action,purity,obtaining,gaining,fulfillment,thing,securing,winning,scoring,accomplishment,integrity,landing,hitting
-onion	
 entitled	permitted,powerful,empowered,privileged,allowed,enabled,honored,qualified,authorized
 arrivals	appearances,beginnings,starts,approaches
 curtain	blanket,furnishing,shade,screen,mantle,wraps,hood,cover,covering,veil,shutter,drop,frontal,decoration,mask,robe,blind,cope
@@ -10143,7 +9600,6 @@ plato	athens
 sock	knock,hose,beat,bop,stocking,strike,punch,hit,bash
 tells	notify,know,express,advise,chronicles,explain,state,disclose,mention,reveals,confess,charts,announce,declare,order,reports,report,identify,learn,say,reveal,see,details,describes,relates,inform,instruct,speak
 agricultural	rural,farming
-langley	
 velcro	fix
 ferry	transport,lug,shuttle,send,ship,convey,deliver,take,bring,haul,tote,carry,cart,pack
 withdraw	move,travel,depart,retreat,bar,eliminate,reverse,fly,leave,go,ban,quit,retire,flee
@@ -10155,7 +9611,6 @@ mil	in,shop,factory,inch,workshop,works,plant
 narrative	memoir,detail,substance,fiction,story,description,version,message,diary,commentary,book,account,report,content,plot,saga,chronicle,commentaries,record,chronology,history,tale
 obliged	compelled,obligated,grateful
 editor	columnist,journalist,correspondent,reporter
-june	
 wrapped	protected,wired,wound,covered
 refinancing	financing,sponsoring,underwriting,supporting,backing,funding,paying,standing,maintaining
 develops	grow,realize,acquire,start,establish,evolve,improve,advance,expand,progress,generate,produce,spread,promote,exploit,proceeds,refine,strengthen,invest,emerges,form,perfect,grows
@@ -10182,18 +9637,14 @@ pack	bundle,horde,haul,stuff,tote,block,pile,seal,lug,ride,band,squeeze,fill,bar
 dash	power,bit,zip,ginger,tear,juice,sap,life,sprint,rush,race,muscle,drive,pep,bolt,slam,bound,vitality,hurry,go,spirit,ruin,gas,starch,fire,punch,speed,snap,energy,beat,dart,bounce,charge,fly,buck,hint,strength,flash,chase,vinegar,smash,plunge,passion,beans,throw,pinch,shoot
 distorted	crooked,mutant,twisted,horrible,abnormal,terrible,ugly
 improve	modify,amend,down,doctor,rise,advance,educate,progress,condition,repair,develop,aid,alter,better,help,reinforce,build,promote,remedy,alleviate,fix,polish,boost,recover,relieve,change,restore,revise,raise,correct,refine,upgrade,strengthen,enhance,increase,lift,reform,perfect
-sle	
 redundant	unwanted,surplus,additional,excess,extra,spare,unnecessary
 legion	numerous,multiple,countless,flock,many,horde,multitude,some,host,army,several
 space	territory,attribute,distance,infinite,room,area,location,way,arena,slot,spot,place,capacity,field,zone
-omissions	
 taking	attractive,engaging,appealing,lovely,delightful,magnificent,gorgeous,hot,beautiful,pleasant,fascinating,charming,pretty,good,likely,superb,glorious,desirable,stunning,cute,handsome,aesthetic,fair,bonnie,elegant,perfect
 mod	latest,stylish,adolescent,teen,designer,contemporary,hot,mods,modern,new,current,fashionable,updated
-finnish	
 corrupted	corrupt,bad,rotten,turned,contaminated
 housekeeping	style,design,practice,strategy,scheme,technique,procedure,approach,routine,program,custom,groove,habit,trick,grind,plan,drill,policy,work,method,fashion,pattern,way,treadmill,manner,practise,tradition,tack
 negotiate	agree,arrange,intermediate,conclude,pass,clear,consult,handle,discuss,bargain,settle,deal,debate,broker,concert
-jets	
 axle	journal
 institutions	institutes,foundations,institute,system,clinic,society,company,charities,school,academy,establishment,establishments,hospital,corporations,business,enterprises,groups,university,association,foundation
 governmental	ministerial,official,parliamentary,legislative,legal,administrative,supervisory,regulatory,presidential,executive,managerial
@@ -10213,7 +9664,6 @@ rick	layer,wrap,bed,accumulation,heap,pile,hill,spiral,aggregate,drift,bank,wren
 theft	crime,robbery,piracy,felony,stealing,petty,fraud
 eq	equivalent
 refreshing	therapeutic,vital,stimulating,sharp,medicinal,helpful,beneficial,healthy,fresh,strengthening
-hindi	
 dwarf	gnome,midget,miniature,dominate,shrimp,scrub,troll,shadow,command,mini
 venom	pesticide,disease,spite,poison,hatred,toxic,virus
 converter	machine,engine,device,mechanism,pastor,transformer,teacher,clergy,equipment,preacher,messenger,motor
@@ -10230,7 +9680,6 @@ kind	style,friendly,charitable,loving,make,kidney,sympathetic,genre,like,stripe,
 sport	pleasure,row,rowing,play,amusement,archery,game,skiing,hobby,athletics,racing,gymnastics,entertainment,cycling,fun,relaxation,enjoyment,recreation,riding,diversion,skating
 maze	system,warren
 savage	beast,criminal,harsh,vicious,fierce,bloody,destructive,violent,rogue,crude,cruel,devil,offender,fell,thug,hound,wretch,monster,nazi,brutal,heavy
-ski	
 instrumentation	transport,means,instrument,ceramic,equipment,connection,medium,connector,arms,device,system,container,apparatus,furnishing,hardware
 exhibition	show,production,presentation,display,demonstration,rodeo,exhibit,expo,fair
 extension	increase,delay,development,expansion,hold,wait,stretching
@@ -10242,10 +9691,8 @@ neural	neurological,visual,sonic,auditory,sensual
 ode	poetry,pastoral,psalm,jingle,lyric,epic,song,poem,limerick,ballad
 gifts	presentations,talent,quality,competence,prizes,presents,bonuses,grants,ability,contributions,awards,offerings,donations,freebies
 merchandise	shipment,export,commodity,commodities,stuff,feature,irregular,generic,cargo,stock,good,ware,freight,line,goods,supply,material,refill,number,inventory,second,loading,load,payload,product,release,outlet
-shaking	
 macon	wine
 optionally	readily,alternatively,either,intentionally,instead,preferably,gladly,deliberately,freely
-baldwin	
 headphone	phone,receiver,headset
 councillor	member,council
 directories	codes,fundamentals,guidelines,commandments,directions,laws,standards,guides,charges,values,practices,bylaws,regulations,restrictions,rules,ordinances,statutes,traditions,acts,commands,directives,instructions,regs,orders,principles
@@ -10266,7 +9713,6 @@ realistic	sensible,vivid,graphic,authentic,possible,prudent,living,real,sound,sa
 two	one,couple,double,fifty,five,dollar,twenty,pair,currency,cardinal,fin,team,ten,dough,buck,money,hundred,chips,cash
 glacier	ice
 unemployed	dismissed,discharged,inactive,idle
-os	
 objectionable	unwanted,bad,unacceptable,obscene,unpleasant,offensive,terrible,foul
 cocktails	bash,combinations,barbecue,mixes,luncheon,reception,dinner,celebration,blends,alloys,composites,mixtures,gala,compounds,feast,banquet
 welcome	adopt,salute,embrace,reception,meet,enjoy,hail,pleasant,like,appreciated,hello,acceptance,greet,hospitality,receive,desirable,satisfying,accept,have,admit,prefer,pleasing,refreshing
@@ -10275,15 +9721,12 @@ glossy	silky,bright,polished,satin,slick,sleek
 bonn	deutschland,germany
 stanford	intellect,power,mind,intelligent,wit,brain,breadth,ability,brightness,stupid
 stationary	parked,static,standing
-alphabetical	
 beer	alcohol,vodka,mead,brew,slug,liquor,wine,belt,peg,mum,ale,gin,sake,cocktail,shooter,pop,whisky,brandy,load,whiskey
-thereto	
 inside	part,midst,interior,region,thick,within,midland
 analytic	empirical,sensible,investigative,rational,valid,reasonable,coherent,cognitive,logical,good,sound,analytical
 priority	preference,arrangement,precedence
 blown	enlarged,expanded,large
 transform	translate,adjust,redesign,change,mold,modify,replace,convert,alter,transfer
-ming	
 mutations	fluctuations,shifts,revisions,conversions,differences,modifications,transformations,amendments,adjustments,variations,reforms,transitions,changes,alterations
 i	unity,digit,one,figure,single
 beat	cream,attack,tan,raid,break,do,mate,trump,shell,master,pulse,top,rush,overcome,club,triumph,belt,slate,shaft,cheat,eliminate,slam,hide,strike,win,rap,assault,hit,batter,punch,jockey,crack,storm,knock,birch,chop,pound,defeat,spank,whip,crush,bat,buffet,lick,box,best,paddle,bash,curry,screw,exceed,slap,rhythm,hammer,smash,switch,lace,wound,worst,whale,scoop,stir
@@ -10305,14 +9748,12 @@ drafts	shipments,loads,weights
 pseudo	hollow,unreal,mock,bogus,mechanical,cute,simulated,forced,artificial,theatrical,fake,affected,automatic,formal,plastic,false,empty,assumed
 authorizing	commissioning,mediation,authorization,consent,concession,filing,arrangement,compliance,enabling,qualifying,investing,understanding,booking,licensing,endorsement,permitting,acceptance,passage,adjustment,empowering,enrollment,evidence,admission,approving,listing,certification,approval,compromise,manufacturing,testimony,accord,verification,accession,allowing,compatibility,proof,reconciliation,recognition,construction
 sizing	distance,length,big,allocation,perimeter,grade,small,analysis,large,arrangement,coordination,distribution,magnitude,little,designation,regulation
-djs	
 tango	samba,jive,trip,dance,bop,boogie,tread,shuffle,waltz,mambo,twist,disco
 garland	anthology,grace,symposium,ornament,compilation,reader,library,ana,corpus,almanac,album,digest
 please	transport,want,warm,excite,charm,wish,cheer,pleasure,glad,like,thrill,wow,entertain,delight,suit,satisfy,content,feast
 soups	clouds
 gu	guam
 beans	dash,power,ginger,zip,juice,sap,life,muscle,bread,drive,pep,vitality,go,gas,spirit,starch,fire,punch,snap,cabbage,lettuce,energy,bounce,strength,vinegar,passion
-verb	
 england	northamptonshire,northumberland,devon,trent,liverpool,thames,kent,manchester,surrey,tyne,lancashire,britain,worcester,berkshire,brighton,somerset,gloucester,cornwall,cumbria,uk,portsmouth,leicester,birmingham,london,lakeland,leicestershire,reading,hampshire,sussex,cam,hull,cambridge,newcastle,essex,hertfordshire,gloucestershire,yorkshire,bristol,coventry,bath,lancaster,avon,oxford,blackpool,lincolnshire,europe
 health	healthy,agility,energy,fitness,welfare,sap,wellness,cleanliness,strength,hygiene
 lebanese	lebanon
@@ -10343,7 +9784,6 @@ denver	colorado,co
 gals	women,girls,lovers,ladies
 simple	honest,elementary,natural,naked,easy,stupid,bald,transparent,basic,direct,clean,smooth,stripped,modest,complexity,classic,plain,silly,quiet,bare,pure,straightforward
 exit	depart,door,departure,farewell,quit,retire,issue,withdraw,mouth,escape,retreat,opening,exodus,gate,retirement,evacuation,outlet,blow,withdrawal
-lucy	
 accumulation	mass,aggregation,clutter,heap,pile,assortment,growth,backup,aggregate,deposition,deposit,collection,inflation,mixture,mix,increase,quantity,sum,gathering
 irs	agency,authority,treasury,office,bureau
 nsw	autonomy,liberty
@@ -10363,15 +9803,12 @@ overlap	share
 sickness	illness,growth,disease,dysfunction,nausea,syndrome,disorder,condition,collapse
 layup	cache,keep,save,acquire,treasure,accumulate,preserve,store,conserve,collect,deposit,pile,gather
 polytechnic	tech
-newswire	
 referenced	illustrated,named,cited,quoted,specified,validated,mentioned,represented,documented
 nurse	attendant,cradle,nanny,therapist,assistant,feed
-asin	
 gothic	unusual
 pastel	dull,light,white,faint,grey,faded,gray,pale,neutral
 productive	creative,profitable,energetic,effective,useful,fertile,rich,successful,dynamic,rewarding,beneficial,worthwhile,constructive,valuable,causal,vigorous
 reverted	declined,returned
-substrate	
 aliases	surnames
 educational	informative,scholarly,informational,instructional,cultural,academic
 herald	announce,friend,apostle,champion,booster,promoter,supporter,tell,advocate
@@ -10394,7 +9831,6 @@ investing	venture,purchase,filling,grant,expense,financing,charging,drowning,flo
 zimbabwe	africa,victoria,salisbury
 undermine	bloody,mar,harm,damage,destroy,flaw,ruin,compromise,wreck,sap,hurt,threaten
 jackpot	swamp,stake,stakes,box,bet,difficulty,dilemma,kitty,crisis,fix,spot,jam,corner,soup,hole,bind
-pelican	
 sparks	flashes,burns,shines,flames,heat,blaze
 bump	node,swelling,growth,knock,tumor,slap,punch,lump,slam,bounce,knot,crash,bang,shake,hit,jerk
 tip	advice,lean,direction,fee,instruction,lead,assistance,prompt,upset,warning,dump,suggest,recommendation,solution,guidance,hint,sign,gift,money,reward,suggestion,tilt,pointer,spill,feedback,end,steer,bend
@@ -10418,7 +9854,6 @@ treatments	approach,conduct,regimen,operation,prescription,practice,analysis,man
 scene	part,show,location,display,arena,place,field,act,locus,backdrop,locale,routine,world,set,setting,darkness,sight,culture,stage,theater,piece,view,background,picture,landscape,spot,scenery,shadow,incident,light,episode,dark,area,site,country
 uncategorized	unclassified
 medicines	pharmaceuticals,prescriptions,pharmaceutical,physics,prescription,remedies,antibiotic,antibiotics,medication,remedy,medications,pills,pill,drugs,drug,cure
-ira	
 chunk	bundle,plenty,mass,myriad,hunk,loads,heap,block,pile,yard,dozen,abundance,bucket,wealth,barrel,ton,sight,piece,mountain,peck,mess,stack,deal,much,portion,bunch,hundred,pot,lump,quantity,volume,store,pack,lot
 calculated	intended,weighed,deliberate,informed,considered,studied,measured,knowing,thoughtful,advised,planned,careful
 emerging	ascending,appearing,approaching,soaring,happening,arising,imminent,growing,occurring,coming,increasing,climbing
@@ -10448,7 +9883,6 @@ compatibility	solidarity,concord,collaboration,peace,unity,friendship,sympathy,h
 expects	predict,require,take,await,forecast,demand,predicts,think,suppose,hope
 lawsuit	bill,argument,complaint,dispute,litigation,trial,prosecution,case,proceedings,action,proceeding,cause,claim,indictment,suit
 stamps	marks,impressions,prints
-amen	
 clerk	cashier,recorder,employee,reporter,secretary,auditor,agent,operator,worker,registrar,teller,register
 starting	first,inaugural,play,beginning,turn,earliest,pioneer,opening,original,foremost,primary,maiden,initial
 extra	unnecessary,excess,new,extraordinary,fresh,supplemental,unused,other,added,ample,redundant,auxiliary,additional,supplementary,unwanted,special,further,ancillary,spare,surplus
@@ -10459,7 +9893,6 @@ esq	cat,stud,stiff,bull,gentleman,boyfriend,fellow,hunk,sir,bachelor,boy,esq,bus
 environ	embrace,contact,touch,border,ring,surround,skirt,meet,fringe,circle,compass
 fries	chow,dinners,potato,murphy,festivals
 nerves	strain,shakes,butterflies
-turkish	
 quarters	bungalow,apartment,dorm,accommodation,place,hall,cottage,shelter,house,pad,accommodations,residence,mansion,roof,dwelling,housing,cabin,lodging,residency,home
 seaside	waterfront,coast,maritime,coastline,shoreline,saltwater,coastal,bank,offshore,aquatic,beach,shore,naval
 ripe	prepared,adult,mature,aging,plump,aged,suitable,ageing,ready,older
@@ -10489,7 +9922,6 @@ summarizes	outlines,recap,outline,compile,briefs
 elephants	giants,titans,whales,monsters,dinosaurs
 demonstration	protest,exposure,exhibition,trial,parade,expression,rally,demo,testimony,gathering,show,strike,presentation,performance,test,march
 juicy	vivid,spicy,fascinating,intriguing,profitable,colorful
-wallace	
 graves	cemeteries
 recurrence	repetition,epidemic,increase,flare,burst,repeat,renewal,return,surge,frequency,outbreak
 facing	lining,mask,cuff,top,covering,front,cover,show,collar,appearance,face,surface,outside
@@ -10498,13 +9930,11 @@ transfer	dispatch,removal,alien,pickup,change,transportation,convey,lease,will,l
 moderators	presidents,chairs,speakers
 fights	battles,beats
 contribute	grant,commit,advance,help,support,assist,lead,strengthen,give,donate,provide,add,share,present,supply,combine
-stanley	
 completion	arrival,expiration,triumph,achievement,success,play,fulfillment,attainment,execution,conclusion,victory,accomplishment,implementation,integration,realization
 how	wherein,where
 infinity	everlasting,time,eternity
 housing	quarters,apartment,condominium,capsule,flat,pod,block,covering,cartridge,house,shelter,cover,camp,construction,plate,armor,hull,hospice,dwelling,structure,case,hostel,shield,shell,coating,package,jacket,home
 daughters	derivatives,descendants,sons
-acapulco	
 deepest	vast,profound,infinite
 nowadays	here,anymore,now,soon,immediately,presently,contemporary,modern,currently,today
 bumper	splendid,superior,automobile,awesome,righteous,capital,sufficient,keen,car,fab,brave,truck,mat,good,classic,beautiful,grand,machine,great,premium,generous,prize,quality,fantastic,choice,immense,top,gone,excellent,boss,shelter,frontline,nifty,phat,heavenly,neat,fabulous,armor,groovy,hot,superb,productive,cracking,safeguard,marvelous,dynamite,unlimited,mean,cool,famous,wizard,decent,swell,radical,hype,wonderful,buffer,stellar,slick,down,prime,terrific,fine,ample,exceptional,banner,cushion,divine,fertile,sterling,better,special,noble,lovely
@@ -10534,7 +9964,6 @@ nsu	nsu
 anybody	somebody,public,everybody,everyone,anyone
 wooden	nervous,stiff,awkward,disturbed,rustic,angular,uncomfortable,thick,upset
 hispanic	american
-fires	
 en	em
 except	object,beside,bar,but,excluding,besides,saving,outside
 bears	has,mothers,drops,delivers,births,produces
@@ -10590,7 +10019,6 @@ style	flair,characteristic,kind,habit,signature,setup,trait,taste,technique,spir
 hs	element
 sub	hero,substitute,submarine,grinder,change,interchange,exchange
 anchors	broadcasters,journalists,reporters
-iceland	
 separation	departure,segregation,partition,breach,dispersion,break,split,cleavage,alteration,change,polarization,dissolution,decomposition,distribution,divorce,modification,division
 clears	facilitates,opens
 charge	tax,rate,concern,tell,complaint,need,damage,indictment,demand,onset,ask,count,request,amount,warn,price,impose,blame,cost,levy,attack,expense,payment,involve,require
@@ -10607,18 +10035,14 @@ incremental	gradual
 teeth	uses,shines,tooth,mouth,tastes,interests,preferences,desires,likes,passions,loves,favors
 flare	explosion,flash,recurrence,surge,outbreak,blaze,explode,flame,renewal,boost,burst,increase,glow,burn,flaming
 password	signal,word,sign,secret
-cody	
 dollar	bone,buck,one,cent,clam,currency
 asserted	declared,alleged,apparent,defended,explained,presumed,proclaimed,justified,announced,affirmed,guaranteed,said
 illustrate	emphasize,demonstrate,elaborate,clarify,interpret,reveal,paint,expose,represent,analyze,exhibit,instance,explain,manifest,mirror,highlight,enlarge,spotlight,specify,mark,expand
-phi	
 bomb	flop,lemon,miss,mine,mess,disaster,rocket,turkey,blast,disappointment,arms,bust,raid,explosive,destroy,loser,failure,frost,attack,device,missile
 kazakhstan	cis,asia
 situation	rejection,posture,status,condition,rank,absurd,case,story,thing,job,size,acceptance,element,environment,picture,affairs,scene,place,deal,trade,exclusion,prison,challenge,circumstances,inclusion,state,position,equilibrium
 sanction	authorization,granting,support,clearance,pass,signature,visa,consent,okay,permit,boycott,certify,injunction,authorize,sentence,confirm,licence,back,allow,approve,endorse,leave,penalty,license,ban,empower,clear,allowance,warrant,accreditation,permission
 networked	dealt,engaged,related,consulted,communicated,discussed
-cherokee	
-ecc	
 night	midnight,evening,day,dusk,twilight,dark,darkness
 beginning	start,birth,dawn,commencement,top,generation,introduction,creation,issue,opening,happening,growth,emergence,onset,origin,heart,conception,launch,morning,threshold,baseline,genesis,alpha,inception
 flea	pest,tick,insect,bee,dragonfly,spider,beetle,mosquito,butterfly,ant
@@ -10628,7 +10052,6 @@ senate	hall,chamber,senate,body,legislature,parliament,capitol,house
 indigo	violet
 madame	madam,dame
 impression	notion,print,impress,theory,concept,feeling,imprint,effect,pattern,opinion,thought,footprint,view,intuition,image,response,impact,reaction,consequence,memory,presence,idea,stamp,mark,perception,suspicion,sense,belief
-reggae	
 saturated	flooded,damp,moist,washed,wet,concentrated,logged
 shall	should,must,will
 columnists	writers,journalists,bloggers,authors,reporters,pens,poets
@@ -10637,7 +10060,6 @@ affected	assumed,impressed,forced,theatrical,cute,simulated,distressed,overwhelm
 olive	beige,black,brunette,dark,ebony,brown
 electives	curricula,institutes,classes,clinics,courses,seminars
 referring	reflective,symbolic,significant,characteristic,expressive,indicative
-preventive	
 onset	start,invasion,strike,offense,blitz,attempt,attack,outbreak,aggression,descent,rush,charge,offence,assault,commencement,offensive,raid
 insulin	endocrine
 soma	man,torso,shape,build,soul,figure,person,human,someone,form,body,bod,somebody,stem,individual,homo,frame,mortal,chassis,anatomy
@@ -10655,7 +10077,6 @@ layered	stacked,gathered,concentrated
 confusing	impossible,embarrassing,complicated,complex,unpleasant,disturbing,uncomfortable,difficult,awkward
 embedded	hard,planted,deep,customary,installed,set,intrinsic,rooted,frozen,fixed,firm,integral,typical,regular,settled,persistent,chronic,inherent,confirmed,natural
 premiere	start,birth,dawn,debut,commencement,advent,arrival,opening,emergence,onset,launch,appearance,morning,threshold,baseline,genesis,beginning,alpha,inception
-hawaii	
 libraries	archives
 around	along,approximately,across,at,nearby,near,by,everywhere,over,almost,about,beside,towards
 render	tube,joint,pump,furnish,supply,top,bush,ticket,index,wharf,stock,uniform,afford,coal,charge,glass,fit,distribute,shelter,tool,railroad,fund,border,bed,do,kern,reproduce,yield,gate,ramp,give,represent,terrace,surrender,hat,leverage,extend,deliver,key,heat,patch,fuel,theme,interpret,transfer,display,seat,water,commit,subtitle,toggle,step,bottom,caption,feed,rail,canal,curtain,pour,rim,arm,partner,costume,headline,outfit,match,provision,equip,articulate,tap,fire,restore,resign,offer,perform,date,provide,edge,abandon,flood
@@ -10666,9 +10087,7 @@ drip	drop,drag,fall,bore
 delays	hold,wait,waits,problem,restrict,suspension,stall,prevent,stay,bar,keep,suspend,lag,block
 seasoned	suitable,accomplished,good,able,trained,capable,practiced,veteran,prepared,equal,qualified,ace,master,competent,experienced,expert,wise,proficient,skilled,knowledgeable,ready,fit
 choice	alternative,opportunity,distinction,prime,superior,deciding,preference,discretion,excellent,judgment,liberty,finding,election,vote,option,pleasure,selection,variety,pick,best,preferred,decision,way,favorite
-paxil	
 gsa	indie,individual,free,separate,independence,autonomous
-continents	
 tank	hold,jail,container,joint,nick,ward,cage,reservoir,hole,slam,vessel,pond,cooler,coop,cell,prison,pool,dungeon,stir,can,pen,block
 noncommercial	nonprofit
 tattoo	symbol,emblem,design,pattern
@@ -10694,7 +10113,6 @@ mib	gigabyte,g,mb,gb,k,kb
 become	turn,transform,come,get,go,settle,take,break,sober,grow,work,run
 hose	tube,stocking,tights,airline,sock,tubing
 pressure	heat,influence,strain,head,strength,press,insist,squeeze,stress,worry,push,load,hardship,burden,weight,suction,trouble,constraint,power,force,tension
-cation	
 pledged	promised,sworn,committed,engaged,guaranteed
 reload	heap,pack,flood,load,charge,restore,refill,bulk,refresh,swamp,recharge,jam,stuff
 conditioned	go,set,qualified,trained,ripe,prepared,armed,ready,fit
@@ -10705,10 +10123,8 @@ autograph	hand,signature
 imitation	reflection,carbon,clone,duplication,reproduction,doctrine,dummy,duplicate,facsimile,mock,replication,replica,impression,parody,copy,version
 garner	get,combine,acquire,concentrate,join,lump,collect,assemble,pack,group,letter,gather,accumulate,reap
 scorpio	zodiac
-fargo	
 ovens	cookers,stoves
 events	circumstances,episodes,occasions,theme,scenario,movement,action,incidents,story,happenings,news,structure,design,experiences,adventures,occurrences,affairs,things,scene,times,accidents,scheme,narrative
-barrie	
 intervene	involve,interfere,intermediate,negotiate
 relevance	applicability,significance,purpose,connection,bearing,importance,point
 challenger	king,favourite,competition,scratch,enemy,champ,queen,competitor,tier,rival,champion,favorite
@@ -10727,7 +10143,6 @@ banquet	barbecue,feed,reception,meal,festival,gala,feast,dinner
 distinguish	discriminate,recognize,differentiate,compare,determine,read,see,identify,know,notice,divide,discover,place,label,difference,contrast,separate,understand,tell,qualify,perceive,analyze,detect,characterize
 briefing	update,mentoring,solution,advice,meeting,brief,teaching,coaching,assistance,input,tutoring,guidance,counsel,instruction,direction,suggestion,observation,feedback,warning,discussion,prompt,reminder,recommendation,signal,conference,information,sign
 adjusted	cooked,organized,renovated,standardized,amended,coordinated,accustomed,supervised,improved,arranged,refurbished,qualified,able,planned,handy,corrected,tested,fixed,inclined,strong,accessible,sure,monitored,willing,weighted,practiced,solid,ripe,processed,modified,transformed,used,apt,enforced,managed,updated,adapted
-gdp	
 quotation	quote,passage,selection,excerpt,extract,citation,reference
 blink	flash,sparkle,wink
 homework	practise,rehearsal,operation,preparedness,appointment,use,study,plan,amendment,preparation,formation,conditioning,teaching,experience,exercise,drill,job,lecture,arrangement,training,alteration,lesson,measure,construction,education,instruction,class,review,test,reading,assignment,practice,improvement,duty,position,drilling,workout,prep,action,discipline,establishment,modification,task,qualification,post,repetition
@@ -10768,14 +10183,11 @@ emission	radiation,exodus,flow,discharge,emergence,flight
 obituaries	memorials,testimonials
 jan	january,christmas,noel
 learners	newcomers,kids,freshmen,beginners
-mayo	
 crucial	decisive,fundamental,key,essential,central,vital,necessary,imperative,polar,compelling,pressing,deciding,urgent,basic,critical,important
 supervisor	administrator,leader,executive,owner,chief,manager,employer,director,ruler,president,monitor,foreman,exec,superintendent,commissioner,superior,principal,boss,counselor
 agreeing	consistent,like,compatible,similar,akin
-rheumatoid	
 derive	assume,reason,conclude,suppose,guess,understand,judge,decide,obtain,ascertain,collect,extract,receive,develop,think,gather,determine,evolve,acquire
 redirect	return,change,direct,switch,convert,whip,transform,move,shift,alter,turn,wheel,send,swing,twist
-gandhi	
 smoker	consumer
 mag	zine,gazette,pulp,bulletin,yearbook,rag,magazine,newsletter,book,periodical,organ,review,quarterly,feature,press,newspaper,monthly,serial,weekly,slick,paper,publication,journal,glossy
 characters	copy,writing,signs,list,lettering,engraving,type,newspaper,icons,edition,symbols,stamp,letters,book,photograph,magazine
@@ -10787,13 +10199,11 @@ temporary	temporal,transient,interim,provisional,limited,unstable,acting,passing
 punctuation	grouping
 offspring	kid,successor,daughter,generation,relative,issue,get,relation,cub,seed,fruit,hatch,baby,son,child,family,young,spawn
 ftc	separate,individual,independence,indie,autonomous,free
-archaeological	
 fusion	blending,assortment,cocktail,blend,merger,composite,mix,mixture,synthesis,alloy,combination,compound
 lacking	flawed,deficient,scarce,sparse,short,wanting,inadequate,insufficient,low,unacceptable,incomplete,shy
 matching	equivalent,comparable,correspondent,corresponding,related,like,alike,similar,such,parallel,twin,duplicate,akin,identical,analogous
 pubs	bars,cafes
 bird	party,customer,face,specimen,individual,man,wing,flock,hen,scout,soul,fish,wight,being,guy,devil,human,creature,sort,mortal,thing,character,person,baby,life,feather,nib,parrot,duck,body,cookie,egg,personality,bill
-cemeteries	
 allowance	aid,adjustment,rebate,accommodation,cut,share,scholarship,fee,gift,deduction,part,pension,piece,salary,proportion,take,wage,end,allocation,quota,annuity,slice,grant,contribution,percentage,portion,subsidy,reduction
 jazz	funk,jive,trash,swing,nuts,fudge,blah,garbage,rubbish,boogie,fiddle,insanity,rot,bunk,beans,madness,bull,nonsense,punk,bop
 practically	almost,basically,most,about,approximately,fairly,virtually,nearly,somewhere,essentially
@@ -10810,7 +10220,6 @@ winning	lovely,leading,beautiful,adorable,attractive,sweet,loved,appealing,preci
 town	hometown,metropolis,municipality,city,township,suburb
 canoe	lighter,yacht,cruiser,vessel,taxi,craft,gig,ferry,shell,kayak,punt
 civilians	citizen
-perry	
 uv	ultraviolet
 lives	pass,endure,living,man,existence,story,time,woman,memoirs,behavior,lifestyle,maintain,lead,soul,thrive,experience,survive,generation,move,occupy,last,season,locate,activity,feed,development,settle,survival,history,person,histories,love,growth,bios,continue,heart,reside,biographies,body,career,personality,remain,world,crash,course
 wight	party,customer,face,specimen,individual,man,scout,soul,fish,devil,being,guy,bod,human,creature,sort,mortal,county,character,thing,person,baby,life,child,duck,body,cookie,egg,personality,bird
@@ -10822,7 +10231,6 @@ composite	whole,blended,hybrid,integrated,combined,mixed,complex,compound
 danger	crisis,condition,vulnerability,emergency,status,uncertainty,risk,distress,probability,trouble,exposure,menace,possibility,threat,instability
 arid	annoying,desert,flat,dusty,dull,slow,sterile,boring,old,stupid,heavy,pedestrian,grey,weary,dry
 employer	administrator,general,organization,governor,leader,master,executive,company,owner,manufacturer,mistress,management,sovereign,chief,entrepreneur,manager,supervisor,director,president,captain,corporation,foreman,commander,superintendent,firm,superior,principal,boss
-cone	
 skincare	facial,attention,care,aid
 bulldog	weekly,community,daily,paper,overcome,journal,press,master,periodical,magazine
 oath	curse,promise,affidavit,deposition,commitment,word,testimony,pledge,assurance
@@ -10841,7 +10249,6 @@ wink	gesture,nap,motion
 slide	flow,creep,move,slip,fall,drive,drift,crawl,glide,submarine,accelerate,sneak,tumble,mouse,snake,drop,steal,shift,skate
 curriculum	clinic,class,institute,program,elective,information,seminar,programme,syllabus,core,course
 warnings	alarms,guidance,recommendations,notifications,alerts,announcements,advice,tips,declarations,notices,predictions,suggestions
-norman	
 quartz	silica
 therapist	physician,psychologist,expert,adviser,analyst,doctor
 supervisory	managerial,departmental,regulatory,organizational,governmental,administrative,executive,legislative,official,ministerial
@@ -10854,14 +10261,12 @@ qualities	classes,trait,excellence,condition,nature,aspect,standards,character,g
 tackle	hardware,face,stuff,rise,confront,gear,tools,resources,apparatus,halt,undertake,kit,machinery,stop,facilities,try,begin,equipment
 slipknot	gin,knot
 appointed	established,announced,selected,determined,unauthorized,designated,fixed,named,arranged,adopted,set,picked,chose,assigned,preferred,specified
-opens	
 stoke	swell,enlarge,up,extend,raise,enhance,multiply,accelerate,maximize,boost,expand,strengthen,stir,hype,reinforce,increase,feed,compound
 rhymes	matches,poetry,poem,corresponds,equals,squares,checks,answers,sorts,goes,rhythm,verse,tune,chords,agrees,consists,fits
 explorers	crew,caravan,safari,trip,settlers,quest,patrol,travellers,undertaking,crusade,trek,pioneers,excursion,travel,outing,travelers,tour,exploration,squadron,cruise
 siam	bangkok,tai,thailand,nan,ping,asean
 sat	park,weekend,install,seat,rest,open,saturday,assemble,set,relax,cover,weekday,remain,meet,lie
 delivery	transport,immunity,passage,transfer,exemption,release,distribution,shipment,bringing,serving,discharge,post,waiver,transmission,service
-a	
 transferred	leased,lent,granted,rented,moved,assigned,left,donated,transmitted
 stripe	band,bar,streak,garment
 vids	tapes,videos
@@ -10889,7 +10294,6 @@ cubes	bays,cabins,cells,boxes,chambers,drawers,holes
 specs	bridge,glasses,goggles,frame,shades,glass,sunglasses
 maori	oceanic
 areas	operation,field,city,territory,sections,range,corners,locality,space,county,square,regions,section,sector,fields,township,neighborhood,state,zones,zone
-morris	
 visibility	resolution,brightness,transparency,clarity
 laughed	grin,scream,smiled
 exemptions	immunity,forgiveness,armor,protection,defense,safety,cover,shield,security
@@ -10899,9 +10303,7 @@ toddler	fry,chick,minor,kid,teenager,monkey,tot,bud,adolescent,infant,chap,teen,
 properties	developments,setting,terrain,decor,furnishings,furniture,landscape,lots,patches,plots,backdrop,parcels,leases
 chatting	visiting,talking,discussing,chatter
 extend	develop,continue,enlarge,allocate,grant,enhance,expand,open,boost,give,stretch,last,take,advance,spread,increase,present
-fiji	
 plots	strategies,designs,schemes
-villages	
 botswana	africa
 earning	acquiring,drawing,carrying,securing,making,obtaining,getting,realizing,achieving,gaining,winning,capturing,landing
 rescued	reconditioned,saved,recovered,restored,released,retrieved,freed
@@ -10919,11 +10321,9 @@ offence	crime,sin,operation,violation,debt,offensive,breach,error,felony,offense
 troop	band,association,crew,soldiers,ensemble,army,contingent,gang,cast,company,military,forces
 licenses	permissions,sanctions,warrants,agreements,grants,permits,certifications,allowances
 rush	go,fly,flow,assault,flash,hurry,flood,break,barrel,move,hustle,encourage,race,run,drive,tear,facilitate,accelerate,zip,speed,dispatch,shoot,press,charge,buck,sprint,surge,stream,blitz,bundle,violence,travel,bolt,dart,push,urge,chase,storm,dash
-nineteenth	
 paving	road,street,route,sidewalk
 spread	transmit,distribute,flow,diffuse,redistribute,advance,increase,export,broadcast,transmission,lay,advancement,multiply,stretch,set,spray,cover,discharge,develop,extend,dissemination,deploy,expand,straw,spreading,reach
 gathered	assembled,joined,combined,packed,grouped,collected,concentrated,accumulated
-grenada	
 success	happening,winner,happiness,prosperity,sensation,advance,hit,fame,victory,benefit,treasure,progress,boom,profit,realization,triumph,win,gem,smash,occurrence,accomplishment,bite,phenomenon,achievement,blockbuster,gain
 ample	good,substantial,full,wide,sufficient,plenty,extra,liberal,great,comfortable,spacious,enough,broad,generous,abundant,adequacy,extensive,adequate
 insect	dwarf,ala,bug,wing,queen,puppet,mosquito,ant,beetle,inferior,number,worker,lightweight,tick,cloud,nobody,pest,flea,shrimp,butterfly,zero,bee,dragonfly,nothing,spider
@@ -10936,23 +10336,18 @@ timeless	enduring,lasting,immortal,everlasting,endless,eternal,perennial,perpetu
 metallic	golden,unpleasant,silver,harsh,noisy,metal,gold
 applicable	pragmatic,usable,suitable,practical,useful,relevant,pertinent,available,applied,practicable,suited,working,functional
 collagen	os,bone
-americana	
 xv	fifteen,cardinal
 opaque	occult,ambiguous,deep,obscure,mysterious,mystic,dull,cloudy,dark,questionable,solid,dirty,uncertain,thick,vague,unclear,confusing
 deals	bundles,tons,barrels,hundred,hundreds,yards,sights,piles,packs,dozens,dozen,stacks,mountains,volumes,loads,pots,masses,quantities,lots,much,stores
 boogie	tango,jive,drift,bop,samba,mambo,twist,trip,shuffle,wander,dance,stroll,tread,waltz,disco,jazz
 type	lot,standard,group,description,category,sample,brand,variation,species,pattern,strain,version,edition,manner,variant,kidney,number,sort,kind,class,genre,write,character,copy,form,stripe,nature,breed,variety
-ib	
-nissan	
 concerts	presentations,festivals,sings,performances
 term	quarter,language,phrase,describe,phase,tenure,style,time,tour,name,word,session,dub,call,duration,course
 dominance	jurisdiction,sovereignty,control,dominion,reign,power,rule,influence
 carbon	equivalent,portrait,coal,spit,fetch,picture,ringer,petroleum,oil,double,crude,duplicate,replica,image,element,duplication,clone,limestone,diamond,graphite,counterpart,char,charcoal,facsimile,c,twin
 configurations	shells,frameworks,fabrics,frames,structures,shapes,architectures
-washer	
 perfection	virtue,cultivation,purity,excellence,precision,fulfillment,evolution,accomplishment,finish,importance,refinement,perfect,ideal,integrity,polish,culture,state,quality
 craft	pottery,skill,drafting,tanning,aircraft,plumbing,trade,plane,business,woodworking,masonry,line,spacecraft,vessel,undertaking,roofing,airplane,art,painting,ship,upholstery,occupation,boat,technique
-ji	
 buddies	companion,friends,colleagues,associate,mate,mates,peer,brethren,pals,sisters,partners
 alameda	plaza,mall,arcade,gallery
 compensated	content,convinced,paid,fulfilled,satisfied,pleased,happy
@@ -10968,14 +10363,11 @@ rolling	swelling,rolled
 penalties	cost,discipline,damages,fine,fines
 refinance	pay,refund,stake,aid,advocate,fund,support,champion,maintain,endorse,finance,sponsor,back
 toward	regarding,about,touching,concerning,of,on,respecting
-nostalgia	
 awards	distribute,honors,assign,donate,reward,badges,allocate,trophy,medals,decorations,scholarship,gift,presentation,donation,prizes,premiums,endowment,gold,accolades,citation,present,honor,grant,verdict,decision
 autographed	signed,autographed
 joseph	stole,domino,cape
 ix	cardinal
-regression	
 hassle	fight,inconvenience,scrap,difficulty,fighting,encounter,combat,argument,brush
-burnett	
 glitter	glance,look,flash,sparkle,wink,glamour,shine,appear,flame,glow
 chasing	pursuit,pursuing,tracking,illustration,tracing,search,tagging,trailing,chase
 force	might,energy,impulse,impose,order,guard,restrict,squad,move,cause,unit,effort,limit,impress,make,drive,patrol,demand,authority,drag,zip,momentum,intensity,require,pressure,troop,press,muscle,charge,capability,violence,army,violate,push,power,battalion,urge,strength
@@ -10987,7 +10379,6 @@ cu	brass,conductor,metal,copper
 surprises	awe,miracle,wonders,curiosity,shocks,shock,revelation,jars,disappointment,wonder
 secretarial	register,registrar,reporter,clerk
 asynchronous	serial
-celebrex	
 saturday	weekday,sat,weekend
 collection	parcel,flora,store,bunch,category,law,heap,sum,repertoire,book,library,fleet,crop,data,content,expo,bundle,family,information,variety,ana,collage,batch,package,universe,compilation,exposition,block,number,signage,packet,fauna,deal,motley,planting,aviation,galaxy,mass,zoology,post,pile,europe,prosecution,accumulation,battery,combination,treasure,clutch,aggregation,congregation,exhibition,mixture,vegetation,mound,findings,wardrobe,defense,hand,string,corpus,lot,grouping,population,asia,supply,assortment,selection,set,botany,ensemble,class,biology,pack,mail,mythology,traffic,arsenal,defence
 commerce	retailing,trade,dealings,business,trading,shipping,transaction,exporting,merchandising,marketplace,transport,selling,industry,noncommercial,economics,ipo,payment,traffic,commercial,distribution,marketing,exchange,interchange,dealing,importing
@@ -11015,7 +10406,6 @@ morrow	prospect,fate,destiny,millennium,outlook,day
 micron	mm
 spiral	curl,curve,arc,coil,wind,circle,turn,sweep,loop,twist,weave
 longest	high,extended,large,deep,big,great,slow,lengthy,tall,late,extensive
-murders	
 fidelity	truth,dedication,attachment,commitment,faith,loyalty,allegiance,devotion,adhesion
 acorn	fruit
 parameters	scope,spectrum,status,field,domain,space,dimension,area,bounds,territory,length,matter
@@ -11024,7 +10414,6 @@ benefit	aid,prosperity,use,enhance,help,serve,advance,assist,resource,assistance
 launching	induction,originating,launch,commencement,creating,appearance,start,proposal,starting,organizing,founding,submission,show,display,origin,delivery,pioneering,introducing,opener,constructing,presentation,beginning,inaugural,reception,planting,establishing,initiating,demonstration,opening,initiation,developing,offering,propulsion,introduction,production
 botany	biology
 allocations	subsidies,funds,appropriations,grants,allowances
-snowmobile	
 ply	sustain,fulfil,horse,help,serve,tendency,supply,board,dish,pimp,staff,accommodate,favor,fill,cater,give,meet,feed,provide,shower,bias,satisfy,bent,power,prejudice,treat,fulfill
 son	offspring,child,kid,daughter,boy,junior,jr
 umbrella	gore,grip,tent,canvas,dome,panel,canopy,hold,arbor,shelter,screen,shade,shield,pavilion,handle,roof
@@ -11077,7 +10466,6 @@ pushes	launch,assault,thrust,attack,offensive,advance,moves,bump,move,boost,init
 convince	persuade,induce,convert,bring,prompt,gain,attract,move,assure,get,urge,argue,prove,satisfy
 awakening	stimulating,waking,refreshing
 knock	bounce,ram,hit,slam,bang,beat,strike,bump,impact,fell,hurt,tap,slap,damage,punch,smash,batter,bash,crash
-cio	
 phrases	saying,wording,slogan,remark,expression,motto,terminology,terms,expressions
 vat	basin,bucket,jar,basket,case,bin,excise,kit,bottle,pitcher,vessel,carrier,pack,bag,bowl,pot,container,kettle,holder
 practice	slavery,rehearsal,operation,use,habit,study,preparation,follow,quotation,observe,fashion,exercise,drill,pattern,usage,train,do,training,activity,cooperation,trial,work,prepare,ritual,apply,rule,custom,pursue,occult,process,form,action,discipline,proceeding,tradition,perform,career,system,experience,execute,method
@@ -11148,7 +10536,6 @@ consists	corresponds,squares,checks,answers,sorts,goes,agrees,dwell,fits
 vermont	us,vt,burlington,usa,rutland,america
 inserted	injected,installed,introduced,added
 rains	showers,storms
-hertz	
 enemies	competitor,opposition,opponents,rival,prosecutor,terrorist,attacker,spy,rebel,opponent,criminal,agent
 helicopter	chopper,blade,rotor
 disability	restriction,hurt,handicap,limitation,impairment,harm,damage,dysfunction,injury
@@ -11175,7 +10562,6 @@ users	freaks,customer,heads,shopper,purchaser,buyer
 thb	commencement,discourse,sermon,preaching
 apartment	suite,saloon,condo,cooperative,flat,condominium,efficiency,housing,studio,penthouse,rooms,duplex
 rounds	rings,road,journey,belts,circles,trail,way,line,passage,avenue,direction,bands,track,eyes,hoops,itinerary,loops,garrison,course
-privatization	
 whipping	pounding,spanking,beating,loss,defeat,licking
 haze	soup,cloud,mist,fog,smoke
 regency	spot,place,situation,position,post,office
@@ -11206,12 +10592,9 @@ procedure	condition,operation,conduct,plan,routine,transaction,formula,move,mann
 rip	bust,break,ribbon,tear,pull,score,split,slash,burst,cut,hack
 grasp	grip,mastery,awareness,clutch,comprehension,accept,realize,direction,control,helm,hold,knowledge,power,appreciate,arm,hang,perceive
 firm	consistent,flat,persistent,explicit,corp,concern,organization,tenacious,rigid,company,stiff,hard,specific,business,fast,robust,thick,sturdy,strong,publisher,interest,association,agency,determined,tough,solid,corporation,tight,substantial,strict,establishment,enterprise,stable,house,steady,dealer
-onyx	
 duplex	double,binary,dual,twin,house
-brunei	
 mahogany	wood
 reflex	blush,concealed,hidden,natural,start,wink,conditioned,jump,flush,unconscious,vomiting,shock,shake,reaction,mechanical,robotic,wind,reactive,mechanic,spontaneous,simple,response,automatic
-agrees	
 lantern	flare,torch,candle,lamp,flashlight,beacon,electric,lighthouse,lighting,chandelier,spotlight
 deal	bucket,thousands,volume,mountain,lot,pledge,appointment,hundred,wealth,peck,score,store,bunch,trade,discourse,heap,myriad,game,barrel,transaction,ton,negotiate,pact,treat,give,arrangement,chunk,sell,accord,abundance,yard,dozen,plenty,initiate,mess,cover,contract,pack,embrace,loads,handle,compromise,quantity,stack,pot,opportunity,discuss,sight,bundle,mass,much,surplus,address,pile,participate,plague
 freed	delivered,quit,discharged,released,free
@@ -11220,7 +10603,6 @@ cloning	duplicate,reproduce,rendering,copying
 scales	balances
 boiler	furnace,heating,vessel,radiator,cooker,microwave,stove,heater,oven,pot
 install	plant,place,lay,station,initiate,institute,seat,fix,introduce,post,receive,put,position,invest,pose
-biosynthesis	
 blue	filthy,stag,abusive,offensive,obscene,wicked,broad,low,crude,nasty,coarse,dirty,infamous,gross,soft,unacceptable,unpleasant,unwanted,foul,off,naughty
 disorder	ill,failure,upset,heck,clutter,trouble,riot,complaint,mess,disturbance,disease,hell,tumble,anarchy,confusion,chaos,sickness,havoc
 theatre	playhouse,circle,pit,house,building,cinema,stage,opera,theater,orchestra
@@ -11233,7 +10615,6 @@ tracks	residues,trails,signs,structure,traces,steps,reminders,paths,grid,web,sys
 gorilla	competitor,hood,pirate,mug,professional,tough,sport,offender,thief,punk,ape,player,criminal,animal,thug
 unforgettable	enduring,extraordinary,persistent,remarkable,memorable
 generous	large,open,compassionate,ample,handsome,acceptable,good,thoughtful,generosity,giving,wealthy,big,reasonable,rich,kind,helpful,willing,tolerant,liberal,charitable,sympathetic,fair,honest,kindly,free
-stewart	
 wardrobe	cabinet,dresser,apparel,closet,press,trunk
 peer	associate,relief,individual,replacement,knight,rival,gentleman,substitute,successor,soul,backup,snoop,stare,equal,mortal,somebody,person,contemporary,lord,match
 memoir	autobiography,life,biography,chronicle,diary,bio,note,narrative,account,essay,thesis,journal,memory
@@ -11249,7 +10630,6 @@ sw	southwest
 rec	fun,hobby,pleasure,diversion,enjoyment,relaxation,amusement
 fraction	scrap,piece,bit,portion,ratio,half,chunk,fragment,chemical
 vacation	honeymoon,break,holiday,picnic,outing,rest,leave,leisure,vac,recess
-yuan	
 edges	frames,point,lip,borders,lead,shore,perimeter,creep,tip,bounds,line,boundaries,mouth,margins,side,peak,ease,lips,margin,rims,end,boundary,corner,rim,skirts,dominance,inch,ends,threshold,fringe
 mosaic	clutter,hash,collage,compound,notions,assortment,accumulation,shuffle,composite,salad,medley,jungle,blend,aggregation,tapestry,motley,art,fusion,rainbow,aggregate,litter,variety,chaos
 applying	pertaining,referring,concerning,relating
@@ -11265,10 +10645,8 @@ messaging	contacting,communicating,talking,approaching,bonding,boarding
 preparations	agenda,curriculum,doses,medications,business,bill,drugs,slate,schedule,plan,remedies,specifics,physics,pharmaceuticals,tablets,record,calendar
 streams	current,courses,cascade,waterways,rivers,glide,rush,flow,channels,tide,torrent,pour,spill,flood,surge
 chubby	full,obese,ripe,gross,round,fat,husky,plump,overweight,thick,heavy,stout
-cholesterol	
 returns	stock,bonus,decision,reward,revenue,compensation,vote,royalty,consequence,brand,earnings,cash,issue,voting,ballot,product,proceeds,output,opinion,premium,interest,development,reaction,crop,survey,salary,commodity,profit,count,fruit,wage,conclusion,work,device,produce,income,pay,event,coupon,replaces,merchandise,surplus,outcome,allowance,amount,gain,production
 entire	concentrated,whole,full,all,integrated,unified,exclusive
-fishermen	
 enterprises	companies,operation,businesses,trade,resource,company,business,project,agencies,establishments,activity,concerns,associations,industry,program,houses,venture,firm,firms,corporations,interests
 rf	ras
 balm	bouquet,cure,aroma,fragrance,lotion,spice,therapeutic,otto,incense,perfume,scent
@@ -11277,7 +10655,6 @@ naturally	consistently,basically,fundamentally,normally,typically,simply,easily,
 score	connect,amount,account,groove,rating,percentile,scratch,get,number,grade,average,accomplish,count,rate,tally,record,notch,result,valuation,mill,win,total,seam,file,add,mark,reach,gain
 archbishop	shepherd,pastor,metropolitan,priest,bishop,missionary,preacher,rabbi,pope,dean
 hazard	danger,trouble,risk,menace,possibility,threat,accident
-fiberglass	
 salt	carbonate,spice,mariner,soda,sulfate,phosphate,acetate,navigator,tar,sailor,compound
 enabled	permit,facilitate,empowered,implement,empower,permitted,allowed,equipped,prepared,let
 smart	formal,stylish,good,bright,tidy,bold,wise,clever,energetic,intelligent,chic,elegant,sharp,fashionable,brilliant,quick,slick,agile,spruce,careful,active
@@ -11301,7 +10678,6 @@ taste	feeling,feel,elegance,grace,appreciate,sample,aroma,bit,chew,understanding
 kelly	olive
 informing	supplementary,advice,tip,revelation,coverage,informative,guidance,counsel,prediction,notification,alert,prophecy,suggestion,warning,predicting,analytical,recommendation,revealing,forecasting,broadcasting
 adjourned	delayed,deferred,suspended,interrupted,postponed,reserved,negotiated
-intestinal	
 defined	naked,extraordinary,surrounded,prescribed,limited,proper,personal,pictured,individual,rigorous,main,significant,primary,deprived,exclusive,measured,different,exact,scientific,solved,planned,unusual,controlled,factual,detailed,special,true,specific,stated,barred,disclosed,rare,specialized,various,appropriate,characterized,discovered,peculiar,specified,bounded,secured,distinct,confined,narrow,precise,authentic,solid,agreed,particular,certain,definite,exceptional,closed,correct,restricted,described,numerous,reduced,strict,bare,blocked,finite,uncovered,major,systematic,careful,memorable,unique,resolved,settled,expressed,definitive
 kiosk	booth,pavilion,closet,casino,stall
 unlawful	prohibited,illegal,wrongful,unauthorized,improper,forbidden,illicit,irregular,criminal
@@ -11335,7 +10711,6 @@ guardians	watches,defenders,watchers,observers,guards
 busted	broken,poor,damaged,broke,neglected,cracked,mild,exhausted,harmless,destroyed,crushed,shattered,exploded,split,collapsed,defective,flawed,needy,injured,gentle,faulty,failed,impaired,ruined
 reprinted	edited,published,issued,printed
 commercial	wholesale,financial,corporate,monetary,technical,economic,profitable
-comedies	
 dad	pop,pa,sire,father,papa,parent,daddy
 concentrated	rich,exclusive,fixed,intensive,big,thick,full,muscular,single,robust,compact,strong,potent,plush,fierce
 gravity	intensity,severity,significance,weight,concentration,urgency,pressure,earnest,consequence,attraction
@@ -11362,7 +10737,6 @@ indiana	lafayette,in,usa,us,evansville,indianapolis,gary,america,bloomington,mid
 franchises	votes,ballots
 cafes	clubs
 beams	rays
-cactus	
 praying	urge,asking,requiring,requesting,ask
 anchorage	marina,cove,dock,alaska,haven,roads,bay,port,lagoon,harbor
 turbine	cylinder,motor,blade,tool,appliance,rotor,weapon,diesel,instrument,generator,transformer
@@ -11374,16 +10748,13 @@ bet	stake,anticipate,chance,odds,pool,call,venture,pledge,speculation,promise,ri
 dy	metal
 expands	supplements,develops
 clarity	purity,definition,focus,clear,transparency,unclear,accuracy,precision,brightness,certainty,simplicity
-gnu	
 explain	analyze,illustrate,resolve,reveal,inform,define,simplify,demonstrate,disclose,interpret,describe,tell,clarify,justify,solve,read,specify
 rpm	rev
 photographed	pictured,shot,filmed
 informational	informative,educational,revealing,academic,useful,scholarly,instructional,helpful,descriptive,explanatory,cultural
 bake	dance,stag,formal,function,reception,benefit,mixer,stew,do,warm,ball,blowout,celebration,tea,party,prom,melt,affair,cook,supper,salon,event,shower,social,blast,bash,heat,symposium
-secretariat	
 benchmarks	measures,standards,metrics,criteria,examples,norms,grades
 borrow	obtain,incorporate,steal,acquire,rent,follow,assume,use,copy,utilize,embrace,hire,adopt
-watson	
 alternatively	sooner,otherwise,rather,instead
 benefits	earnings,interest,help,royalty,pay,profit,advantages,compensation,cash,resources,salary,proceeds,assets,revenue,wage
 holidays	vacations,festival,breaks,vacation,feast,anniversary,celebration,recess,break,gala,leaves
@@ -11396,7 +10767,6 @@ polaroid	shades,film
 venture	endeavor,adventure,project,operate,deal,gamble,investment,chance,go,enterprise,undertaking,experiment,speculation,move,bet,dare,throw,flyer
 celeb	acclaimed,eminent,name,personality,remarkable,distinguished,celebrity,notorious,known,noble,notable,glorious,superstar,prominent,recognized,someone,figure,outstanding,vip,renowned,important,light,icon,hero,popular,infamous,star,leading,noted,splendid,somebody,reputable
 worse	common,poor,deficient,everyday,worst,wanting,ill,frequent,inferior,bad,routine,usual,ordinary,ubiquitous,lower,bush,household,unacceptable,normal,familiar,depressed,off,lame,lesser,garden
-bookmark	
 understands	thinks,judges,reads,reasons,concludes,assumes,decides
 years	times,days,cycles,spans,periods,generations,spaces,ages
 defenders	protections,guards,guardians,champions,protectors
@@ -11405,7 +10775,6 @@ amongst	mid,through,midst,between,amid
 nationalist	national,patriotic,subject,patriot
 representative	agent,replacement,ambassador,attorney,distributor,factor,contact,counselor,member,proxy,spokesman,rep,deputy,delegate,minister,manager,spokesperson,senator,commissioner,lawyer
 dwell	reside,exist,remain,stay,abide,worry,wait,care
-lung	
 awake	alive,alert,about,aware,conscious,waking,up
 reveals	acknowledge,confess,inform,explain,declare,discovers,shares,admit,publish,expose,announce,leaks,affirm,report,display,tell,tells,disclose,publishes,unveils,announces
 heavens	length,size,sky,radius,width,zodiac,breeze,pressure,orbit,atmosphere,space,sphere,apex,span,gap,scope,stretch,wind,zenith,area,separation,air
@@ -11418,7 +10787,6 @@ squirt	discharge,rush,run,wash,flush,pour,spit,stream,jet,splash,spray,roll
 interact	control,meet,combine,discuss,gather,communicate,interfere,associate,relate,manipulate,intervene,engage,handle,mesh,invite,treat,move,network,collaborate,have,cooperate,act,assemble,merge,affiliate,connect,deal
 workshop	studio,laboratory,workplace,factory,shop,works,seminar,work,class,pottery,mill,plant
 sen	subunit,yen
-ron	
 detective	agent,operative,reporter,officer,investigator,spy,tec,prosecutor
 sic	rush,bomb,apparently,urge,drive,precisely,attack,really,indicate,quite,well,hound,thus,cause,remind,help,trash,convince,mob,push,spark,then,induce,press,rob,completely,too,spur,stimulate,assault,therefore,charge,actually,trigger,truly,motivate,raid,prompt,persuade,draw,suggest,inspire,prod,harry,indeed,tease,stir,very,directly,storm,simply,strike
 trademark	logo,stamp,copyright,label,brand,characteristic,hallmark,patent
@@ -11436,7 +10804,6 @@ calendar	diary,card,journal,almanac,list,schedule,chronology,lineup,agenda,table
 insulated	retired,separated,detached,divided,remote,withdrawn,isolated,separate,isolate
 healthy	hardy,athletic,well,strong,firm,vigorous,hale,whole,fit,bouncing,fresh,good,robust,lively,health,active,tough,sound,normal,rugged,sturdy,wellness,agile
 he	she,xe,sie,you,they,i,it,element,ve,helium
-magnolia	
 maintainer	defend,conserve,backbone,supporter,preserve,restore,pillar,booster,protect,save,friend
 itinerary	diary,guidebook,tour,path,journal,plan,blog,route,journey
 suspension	termination,latency,freeze,period,coma,recess,halt,recession,break,mixture,interruption,suspense
@@ -11471,7 +10838,6 @@ removal	demolition,discharge,dumping,withdrawal,abstraction,stripping,eliminatio
 percentages	odds,possibilities,chances,probabilities
 spontaneous	simple,unwilling,reflex,unconscious,quick,sudden,voluntary,mechanic,reactive,mechanical,natural,intuitive,automatic,robotic,casual
 cabernet	colorful,coloured,red,colored
-sabbath	
 warn	threaten,inform,hint,suggest,address,notify,recommend,prompt,order,caution,remind,urge,advise,signal,wake,prepare,tell,alert,instruct,predict
 shouted	cheer,yell,loud,whispered,scream
 voters	land,anybody,population,district,precinct,society,faction,county,audience,everybody,region,everyone,nation,community,country,enrollment,turnout,people,state,public
@@ -11501,7 +10867,6 @@ compression	encryption,contraction,mpeg,consolidation,squeeze,contracting,encodi
 predictions	prophecy,signs,guess,forecasting,indicator,forecasts,forecast,casts,prognosis
 isolation	insulation,confinement,segregation,secrecy,separation,privacy
 servings	meals,fries,tastes,breakfasts,bites,snacks,dinners,plate,teas,boards
-imf	
 reforms	adjustments,fluctuations,replacements,shifts,transform,resolve,amend,variations,alterations,corrections,repair,revise,transformations,improve,regulations,revisions,amendments,conversions,differences,mutations,modifications,changes,restore,remake,rebuild
 lipstick	oil,cosmetics,rouge,makeup,cream,lotion,powder,blush,paint
 affiliations	relationship,collaborations,relations,associations,interactions,alliances,unions,partnerships,dealings,partnership,connections,relationships,connection,mergers
@@ -11530,11 +10895,9 @@ channel	vehicle,canal,tunnel,convey,instrument,carrier,agency,medium,means,trans
 arch	premier,prior,sovereign,arc,dominant,key,principal,curve,chief,master,first,central,primary,foremost,cardinal,grand,greatest,main,bend,supreme,flex,big,great,top,leading,highest,paramount,capital
 lifetime	duration,date,career,span,birth,period,hereafter,term,life,death,dying,standing,time
 religious	spiritual,holy,sacred,faithful,ritual,theological
-copenhagen	
 knowingly	deliberately,voluntarily,intentionally
 normalized	standardized,integrated,organized,regulated
 limerick	psalm,epic,poetry,ballad,ireland,lyric,verse,poem,song,pastoral,jingle,composition,writing,ode
-oval	
 torn	rent,broken,cracked,damaged,ripped,cut,divided
 italicized	reinforced,enhanced,underlined,emphasized,stressed
 creek	stream,burn,canal,runoff,brook,beck
@@ -11560,7 +10923,6 @@ directional	guiding,directing,directive
 ratification	confirmation,support,goodwill,agreement,blessing,consent,enactment,vote,favor,okay,accession,sanction,authorization,nod,ok,backing,endorsement,approval
 whispered	hard,shouted
 indications	shot,likelihood,signals,hints,prospect,implications,outlook,signs,opportunity,leads,clues,odds,cues,suggestions,break,ideas,time
-bo	
 improves	remedies,recover,raise,upgrades,lift,promote,increase,revise,rise,better,enhance,correct,progress,upgrade,helps,enhances,reform,advance,help,develop,boost
 encrypted	coded,encoded
 savanna	lea,meadow,champaign,field,prairie,plain,savannah,heath
@@ -11578,8 +10940,6 @@ items	elements,members,problem,evidence,objects,development,idea,plan,stuff,arti
 transparent	sincere,honest,liquid,lucent,candid,easy,straightforward,sheer,thin,crystal,clear
 echoes	repetition,mirror,rings,respond,recall,sounds,reflection,ring,parallel,imitation,reflect
 descent	dip,ancestry,fall,extraction,down,dive,lineage,origin,plunge,drop,slide,decline
-sinclair	
-jerome	
 dyke	canal,barrier,dam,lesbian
 stern	hard,severe,tough,demanding,strict,rigid,grim,harsh,rigorous
 systematically	regularly,widely,totally,completely,consistently,fully,thoroughly,extensively
@@ -11589,11 +10949,8 @@ surfing	browsing,researching,viewing,scanning,studying,cruising
 parsons	monks,fathers,missionaries,bishops,priests,padres
 open	sincere,transparent,suitable,prize,expand,launch,available,vacant,accessible,breach,jimmy,commence,unlock,meet,gap,lever,release,start,susceptible,appropriate,impartial,free,clear,initiate,fair,wide,lance,public,candid
 chaotic	messy,stained,dirty,filthy,nasty,confused
-barber	
 dose	medicine,tablet,quantity,measure,lot,booster,capsule,cap,drug,tab,application,remedy,shot,dosage,prescription,medication,pill,cure,hit,measurement,draft
 lawn	backyard,grass,terrace,green,clearing,field,garden,ground,yard,park
-adrian	
-joshua	
 laboratory	work,workshop,lab
 guinea	poultry
 shoe	oxford,boot,platform,tongue,sandal,footwear,counter,heel,saddle,lace,fin,sling,collar,throat,upper,pump,walker,spike
@@ -11612,12 +10969,10 @@ lawsuits	actions,suits,complaints,proceedings
 terminator	killer,slayer
 custom	usage,fashion,policy,ritual,habit,system,way,procedure,method,addiction,rule,trick,practise,style,practice,survival,mode,wont,tendency,pattern,characteristic,routine,use,rite
 active	functioning,dynamic,viable,lively,functional,on,quick,enthusiastic,aggressive,intense,operating,ready,eager,bold,determined,energetic,operative,engaged,operational,going,alive,keen,busy,working,live,living,running,effective
-wins	
 signalling	informing,signing,telling
 silver	knife,tableware,setting,metal,bright,spoon,fork,cutlery,white
 mention	recognition,notification,advert,indicate,reveal,raise,announce,detail,instance,imply,notice,suggest,introduce,comment,footnote,reference,indication,note,mean,remark,quote,refer,specify,cite,remember,disclose,acknowledge,explain,appeal,name,tell,report,declare,discuss
 josh	ride,laugh,rag,joke,gag,cod,rib,bait,tease,funny,rally,sally,jolly,nifty,scream,kid
-servers	
 ballroom	room,theatre,hall,lounge,theater,playhouse,disco,auditorium,garden,gym,arena,senate,church,house,gallery,chamber
 boo	raspberry,bird,whistle
 vocals	lyrics,songs
@@ -11633,7 +10988,6 @@ mastery	control,command,iq,ability,proficiency,skill,comprehension,familiarity,e
 booking	work,engagement,employment,hiring
 knots	batteries,bands,suites,packages,mixtures,blocks,groups,arrays,clusters,sets,series,banks,varieties,collections,parcels,lots
 jaguar	leopard,tiger,panther,cat,puma,lion,lynx,cub
-ph	
 residing	staying,dwelling,living
 feminist	feminism
 singled	designate,pick,name,choose,tag,prefer,elect,take,select
@@ -11643,7 +10997,6 @@ mortar	lime,glue,rifle,hardware,pistol,shotgun,plaster,cement,piece,sand,mud,can
 illustrator	demonstrate,specify,clarify,analyze,instance,explain
 rhythm	swing,emphasis,meter,pulse,flow,drum,pattern,tempo,accent,beat,movement
 jury	alternative,separate,other,tribunal,spare,extra,body,utility,successive,second,different,board,pinch,alternate,another
-kissed	
 functional	going,use,active,functioning,operating,viable,practical,working,on,operative,function,operational,purpose,live,useful,running,structural
 knee	clip,slap,counter,pound,stripe,rap,dab,lick,cuff,spank,swing,beating,licking,kick,bust,hack,pick,right,blow,leg,bat,hook,hand,box,slam,slug,stroke,knock,left,sock,pounding,buffet,beat,whip,crack,plump,switch,chop,bop,ko,punch,hit,bang,belt
 waves	impact,effect,lake,ocean,response,influence,tsunami,aftermath,outcome,consequence,development,reaction,seas,surf,issue,event,pond,realization
@@ -11685,9 +11038,7 @@ mutation	transformation,conversion,revision,difference,deformation,revise,distor
 blocking	conflict,refusal,support,intervention,interference,obstruction,intrusion,block,protection,failure,fight,struggle,illustration,frustrating,irritation,grievance,battle
 pianist	drummer,maestro,piper,artist,performer,player,guitarist,musician
 controlled	measured,composed,calculated,supervised,moderate,dominated,deliberate,contained,structured,ordered,organized,possessed
-mu	
 cells	muscle,rooms,beef,apartments,chambers,meat,fat
-roi	
 equip	train,furnish,provide,stock,spur,supply,wire,arm,armor,ready,set,gear,kit,shaft,decorate,fuse,instrument,fin,render,outfit,teach,invest,dress,enable,prepare,armour,collar,commission,fit,qualify,rig
 corp	corporation,house,firm,empire
 burnt	burning,hot,lighted,burned,live,lit
@@ -11738,7 +11089,6 @@ fragment	crush,chip,shaving,bit,split,piece,bust,smash,fracture,reduce,ruin,dest
 tasks	responsibility,work,projects,exercise,assignment,duties,effort,jobs,burden,responsibilities,assignments,project,function,undertaking,duty,business
 ss	law
 occasional	unpredictable,intermittent,random,irregular,casual,odd,sudden,particular,violent,rare,unusual
-henry	
 killed	broken,dead,dispatched,claimed,murdered,wasted,got,injured,ruined,shattered,wounded,lost,executed,loss,destroyed,took
 icons	figure,gods,idol,symbol,portrait,heroes,models,classics,picture
 customizing	preparing,putting,fitting,adjusting,modelling,modifying,conditioning,tuning,matching,editing,modeling,shaping,transforming,altering,conforming,establishing,correcting
@@ -11747,7 +11097,6 @@ slogan	saying,phrase,expression,cry,jingle,motto,banner,trademark
 gloves	corners,arrests,nails,bays,ropes,gets,cops,lands,nets,grabs,bags,traps,collars,captures,hooks,grips,catches
 dissent	division,conflict,war,argument,contention,differ,clash,warfare,opposition,disagreement,variance,friction,resistance,dispute,divide,objection,debate,protest
 aggression	offensive,invasion,violence,assault,fight,raid,action
-floral	
 comments	advertisement,notification,commentary,criticism,manifesto,story,picture,analysis,advice,comment,memorandum,instruction,order,note,remark,poster,review,memo,observation,directive,news,exposition,warning
 word	loan,phrase,conversation,derivative,substantive,advice,language,talk,opposite,saying,descriptor,sound,comment,message,remark,hybrid,subordinate,assurance,information,concept,speech,primitive,news,rumor,account,form,head,contraction,name,report,pledge,expression,term,announcement,terminology,synonym
 locality	where,zone,section,district,parish,locus,proximity,locale,location,venue,region,position,site,spot,neighbourhood,scenery,neighborhood,place,vicinity
@@ -11758,7 +11107,6 @@ methodology	mode,approach,course,method,policy,technique,procedure,program,plan,
 magnitude	degree,bulk,property,amount,weight,quantity,capacity,extent,importance,significance,order,measurable,moment,intensity,import,breadth,strength,consequence,dimension,value,amplitude,gravity,volume,proportion,mass,measurement
 creators	author,maker,fathers,authors,generators,designers,pioneers,architect,makers,founder,founders,designer,producer
 dr	resident,physician,md,extern,veterinary,doctor,specialist,gp,doc,intern,surgeon
-sam	
 blackboard	sheet
 regulating	limitation,stopping,checking,governing,performing,ruling,containing,control,arrangement,keeping,measuring,timing,modification,regulation,improvement,alteration,controlling,holding,running
 yard	lea,grass,patio,garden,playground,rod,quad,lot,pace,pole,plaza,foot,chain,courtyard,court,ft,lawn,backyard,patch,enclosure,close
@@ -11771,7 +11119,6 @@ pu	element
 parks	campuses,yards,lands,estates,premises,acres,properties,grounds,gardens
 crap	bm,bull,nonsense,dirt
 khz	hertz,mc,kc,cycle,khz,cps,hz,rate,mhz
-larvae	
 cut	clip,separate,dice,slice,cube,bore,tap,cradle,chip,decrease,drill,split,hack,rebate,saving,chase,bob,saw,trench,divide,nip,nick,chatter,part,fell,reduction,plane,shave,shear,drop,pink,rip,dock,chop,trim,stab,pierce,slash,tail,wound
 element	division,item,component,section,bit,detail,piece,matter,aspect,material,member,part,constituent,basis,factor,characteristic,view,principle,fundamental,ingredient
 ig	antibody
@@ -11794,13 +11141,10 @@ integration	absorption,incorporation,mix,mixture,synthesis,accumulation,coalitio
 bows	corners,rings,turns,curves,folds,slopes,winds,angles
 giving	gift,endowment,offering,donation,sharing,feminine,caring,contribution,accordance,charity,female,parental
 fed	federal,squad,tracker,reporter,man,troops,detective,force,shadow,agent,police,officer,prosecutor,spy,operative,tail
-escherichia	
-tnt	
 projected	predicted,cautious,thoughtful,planned,conscious,upcoming,potential,future,awaited,relieved,sticking,expected,subsequent,possible,anticipated,eventual,calculated,careful,prospective,prudent
 carries	packs,brings,give,bear,lift,move,remove,takes,pack,transport,ferries,haul,import,release,bring,display,ships,lug,bears,delivers,sends,publish,transfer,offer,carts,ferry,drive,tote,transmit,get,air,take,send
 monuments	tablet,stone,pillar,markers,shrine,crosses,tribute,testament,marker,tomb,stones,plaques,masterpiece,slab,statue
 toss	sky,rock,roll,pitch,halt,submarine,jerk,shake,tumble,flip
-french	
 carolina	south,sc,nc
 normal	average,usual,whole,everyday,standard,reasonable,typical,natural,mean,common,traditional,expected,healthy,modal,sane,regular,familiar,routine,ordinary,customary,cool
 commons	mob,herd,multitude,millions,crowd,people,mass,public,class
@@ -11816,14 +11160,12 @@ ministry	department,vehicle,incentive,instrument,mechanism,agency,medium,influen
 editing	deletion,review,correction,modification,improvement,alteration,printing,publishing,amending,polishing,reading,compiling,amendment,cut,writing
 eureka	curiosity,revelation,disappointment,california,miracle,wonder,awe,shock
 signs	authors,autographs,pens,inks,registers
-dominican	
 ranging	roaming,wandering,migrant,walking
 negotiated	postponed,concluded,managed,discussed,delayed,regulated,arranged,fulfilled
 stag	crude,snoop,filthy,dirty,unwanted,singular,obscene,coarse,solitary,supervise,offensive,unpleasant,spy,enquire,discover,function,examine,dance,gross,abusive,naughty,lone,blue,fiesta,prom,unacceptable,only,bash,celebration,sole,wicked,foul,infamous,broad,off,investigate,inquire,monitor,lonely,nasty
 heavyweight	princess,giant,heavy,lion,tycoon,wheel,king,baron,queen,big,celebrity,titan,prince
 constructor	design,manufacture,builder,produce,contractor
 press	push,petition,squash,crunch,force,demand,grind,writer,publisher,squeeze,urge,magazine,media,worry,crush,reporter,journalist,closet,sue,touch
-macedonia	
 incorporates	mix,consolidate,organize,combines,integrates,fuse,cover,integrate,blend,merge,absorb
 conversions	modifications,alterations,transformations,shifts,transitions
 bologna	sausage,frank
@@ -11849,7 +11191,6 @@ alliance	convention,combination,covenant,pact,allies,coalition,organisation,comp
 statute	bill,amendment,measure,rider,enactment,regulation,ordinance,act,prohibition,law,legislation,decree,constitution
 servant	butler,man,assistant,attendant,daily,familiar,woman,companion,valet,domestic,helper,maid,groom,worker
 shattered	defective,ruined,injured,broken,fragile,destroyed,collapsed,wasted,cracked,damaging,split,crushed,dead,adverse,finished,exploded,busted,used,lost,damaged,inappropriate
-napa	
 propane	fuel
 identity	identification,character,unity,personality,equivalence,existence,integrity,equality,name,similarity,status
 pot	cup,pool,jack,bet,can,vessel,boiler,basin,jackpot,urn,stake,mug,dixie,bowl,bucket,pan,cookware,kettle,jar,fund
@@ -11867,13 +11208,11 @@ universal	unlimited,versatile,worldwide,global,flexible,cosmopolitan,extensive,c
 python	asp,racer,cobra,snake,viper,boa
 soldiers	squad,guard,marines,army,warriors,fighters,recruits,rangers,command,patrol,battalion,infantry,troop,artillery,corps,raiders,veterans,knights,unit,troops,company
 affirm	support,assert,insist,verify,establish,guarantee,demonstrate,validate,maintain,warrant,back,declare,confirm,repeat,claim,sustain,protest,show,document,announce,argue
-lydia	
 folded	locked,twisted,closed,curved,doubled,sealed,shut
 doctorate	dd,std,degree,do,md,dds,od
 amsterdam	nederland,netherlands,holland
 shaping	bending,matching,painting,modification,improvement,establishing,arrangement,regulation,preparing,altering,modifying,transforming,conditioning,alteration,process,fitting,putting,adjusting,conforming,customizing,design,editing
 displaced	needy,reduced,disadvantaged,broke,deprived
-threesomes	
 delivered	quit,freed,released
 heaven	paradise,zion,part,nirvana,bliss,above,glory,sky,sion,region
 nationality	citizenship,race,position,family,minority,ethnicity,society,community,nation,origin
@@ -11921,7 +11260,6 @@ helmets	hats,hoods,caps
 heath	meadow,plateau,prairie,field,bush,ling,savannah,heather,champaign,lea,pasture,plain,erica,savanna
 princess	emperor,shah,royalty,queen,girl,woman,tycoon,female,diva,goddess,king,executive,monarch,sovereign
 dust	debris,truck,litter,dirt,sewage,scrap,particulate,powder,spray,sand,garbage,refuse,soil,rubbish,trash,junk,earth,waste
-gagged	
 filed	ground,reported,listed,documented,polished,registered
 cookers	ranges,ovens,stoves
 ethics	conscience,motive,standards,need,values,light,principles,morality,norms
@@ -11933,11 +11271,9 @@ settings	situations,surroundings,spaces,locations,places,surrounds,contexts,elem
 electoral	elected
 goat	nanny,kid,monkey,billy,beard,victim,excuse
 textile	cord,linen,acrylic,goods,network,filling,waterproof,metallic,cloth,nylon,terry,fibre,warp,knit,satin,canopy,plaid,velvet,elastic,lame,tweed,macintosh,mesh,suede,material,yarn,web,canvas,pick,polyester,jean,wool,tammy,cotton,duck,hem,plush,tapestry,diaper,fabric,net,screening,fiber,print,hair,rep,fleece,felt,coating,silk,aba,quilting,denim,lace,cashmere,velcro,motley
-pascal	
 daycare	kindergarten
 label	address,classify,mark,sticker,tag,designate,identify,ticket,seal,specify,brand,logo,marker,characterize,plaque,stamp,number,direct,legend,symbol,trademark,name,define,design,call,caption,company
 allies	supporters,friend,alliance,colleague,partner,colleagues,friends,alignment,partners,associates,assistants,coalition,associate
-holster	
 drums	cans,barrels
 fixed	hard,locked,agreed,certain,firm,precise,flat,rigid,specific,definitive,hooked,resolved,restricted,steady,final,tight,definite,established,stable,stated,uniform,frozen,set,constant,settled,defined,limited,planned
 resistor	resistance,circuit
@@ -11947,7 +11283,6 @@ bucks	money,cabbage,coin,change,capital,wealth,scratch,tender,currency,bill,paym
 trays	servers,plates,chargers,bowls,cups,dishes
 assays	examinations,inspections,assessments,evaluations,analyses,investigations
 suffix	ending,postfix
-liberals	
 trained	drilled,familiar,gentle,competent,broken,qualified,prepared,equipped,experienced,skilled,domestic,bred
 meeting	summit,workshop,demonstration,assembly,rally,convention,conference,conversation,session,showdown,date,council,symposium,agreement,congress,reunion,confrontation,talk,caucus,contest,contact,gathering,discussion,encounter,competition,seminar,forum
 arising	ascending,awakening,rising,mounting,climbing,waking,soaring
@@ -11978,7 +11313,6 @@ grouping	system,mixture,association,batch,population,masses,package,community,bu
 highlighted	bright,advertised,illuminated,displayed,light,lit,lighted
 designs	configuration,ideas,make,motif,model,plans,prepare,games,style,arrange,drawing,projects,fashion,idea,project,programs,construct,recipes,portrait,perform,aim,scheme,systems,ways,create,compose,method,story,setup,painting,arrangements,picture,arrangement,device,shape,plan,describe,devices,draft,pattern,strategies,map,composition,schemes,produce,recipe,tailor,study,architecture,layout,propose,form,construction,proposals
 counting	arithmetic,estimate,census,count,investigation,checking,tally,susceptible,computing,forecast,calculation,judgment,conditional,relying,numbering,estimation,countdown,poll,computation,investigating,calculating,enumeration,prediction,telling
-ivory	
 professionals	pro,fans,artist,specialist,specialists,expert,enthusiasts,pros,consultants
 constitutes	forms,establish,comprises,create,empower
 observers	viewers,witnesses,watchers
@@ -12007,7 +11341,6 @@ griffin	cat
 obvious	manifest,visible,bald,pronounced,noticeable,decided,patent,transparent,accessible,ringing,evident,plain,frank,clear,simple,broad,open,apparent,distinct,understandable,straightforward
 asylum	residence,harbor,sanctuary,retreat,lodging,oasis,shelter,harbour,refuge,haven
 slate	catalogue,book,schedule,register,index,enroll,enter,file,specify,list,record,catalog,roster,designate,ballot,card
-whores	
 vinegar	fire,energy,beans,muscle,dash,drive,juice,life,bounce,pep,vitality,gas,passion,strength,ginger,punch,zip,sap,spirit,power,go,starch
 constructed	assembled,produced,manufactured,devised,completed,fabricated,conceived,lifted,shaped,invented,designed
 mechanical	unwilling,natural,spontaneous,unconscious,automatic,simple,mechanic,sudden,reflex,robotic,automated,quick
@@ -12024,13 +11357,11 @@ averaged	measured,reached,numbered
 westminster	london
 toxins	contamination,viruses,pesticides,diseases,venom,infection,virus
 boxing	cracking,batting,kicking,tagging,tapping,pushing,licking,striking,pounding,knocking,enclosure,packing,hitting
-nicotine	
 surprised	shocked,wondering,overwhelmed,amazed
 falling	limp,suspended,decreasing,sinking,descending,declined,declining,down,sliding,hanging,floppy,lowering,pendant
 shelters	retreats,residences
 materially	considerably,potential,making,stuff,timber,substance,substantially,physically,possibility
 tacoma	wa,washington
-diets	
 highway	pike,drive,avenue,pass,bypass,arterial,interchange,lane,street,interstate,artery,roadway,track,path,route,boulevard,parkway,road,freeway,way
 bill	proposal,measure,note,tab,check,document,rider,agenda,rate,cost,record,invoice,program,price,instrument,receipt,draft,card,account,debt,statement,act,fee
 telecommunication	ee
@@ -12059,7 +11390,6 @@ mens	convenience
 tumble	aggregation,hash,assortment,collage,combination,medley,slip,litter,spill,fall,plunge,stew,flop,drop,accumulation,salad,clutter,blend,jungle,motley,aggregate,variety,dip,shuffle
 hobbies	sports,diversion,specialty,obsession,art,occupation,amusement,craft,sport,fun
 energetic	animated,muscular,driving,vigorous,fit,powerful,dynamic,spanking,strong,active,kinetic,tough,aggressive,capable,hale,mighty,vital,lively,healthy,athletic,alert,physical,spirited,merry,robust
-asthma	
 puzzles	secrets,mysteries,problems
 stacks	hundred,yards,stores,wealth,crowd,loads,abundance,masses,torrent,pots,tons,lots,library,multitude,bundles,enough,packs,piles,quantity,group,load,barrels,hundreds,quantities,volumes,mountains,deals,bunch,much,collection,dozen,set,dozens,sights,luxury,plenty,number
 wb	weber,wb,mx
@@ -12080,7 +11410,6 @@ ridiculous	insane,impossible,fantastic,incredible,foolish,silly,pathetic,stupid,
 x	cancel,adam,xtc,go,delete,remove,ecstasy,erase
 tickets	vouchers,tokens,coupons,passes,notes,certificates,checks
 hail	storm,recognize,endorse,cheer,recommend,greet,rain,praise,salute,welcome,address,herald,acknowledge,acclaim,tout,shower,signal
-panda	
 greedy	eager,avid,selfish,hungry
 receivable	owing,owed,payable,due,outstanding,unpaid
 care	attention,focus,diligence,concern,concentration,protection,responsibility,observation,nurse,effort,precision,want,supervision,attend,protect,love,watch,pains,trust,enjoy,load,compassionate,pity,tend,control
@@ -12088,7 +11417,6 @@ occupational	calling,job,profession,game,duty,employment,line,work,trade
 conclusions	decisions,deductions,statistics,input,consequences,determinations,testimony,assumptions,goods,info,evidence,picture,knowledge
 influencing	lobbying,convincing
 portability	flexibility
-lm	
 statutory	legal,permissible,constitutional,lawful,authorized,right,innocent,proper,allowable,regulation,just
 israeli	asian,zion,sion
 assistants	servants,administration,ministry,organization,aides,authority,team,crew,aids,helpers,government,employees,force,committee,faculty,personnel
@@ -12115,8 +11443,6 @@ tissues	towels
 axis	playground,hub,central,nucleus,base,capital,seat,focus,heart,center,nexus,headquarters,locus,line,core
 vac	vacation
 learnt	read,enroll,study,see,hear,understand,determine,gain,get,review,receive,grasp,master
-librarian	
-easter	
 spaced	separated,unique,curious,dispersed,remarkable,queer,weird,rare,uncommon,rum,odd,wacky,unusual,abnormal,strange,distributed,funny,crazy,bizarre,peculiar,funky,wild
 sierra	elevation,volcano,cliff,pike,butte,bluff,mountain,range,knob,mesa,ridge,mount,peak,height,tor
 stomach	middle,belly,crop,tummy,waist,gut
@@ -12132,7 +11458,6 @@ arrests	collars,captures,grabs,commits,nails,catches,traps
 influence	consequence,mastery,authority,hold,money,leverage,direction,importance,leadership,weight,alter,change,guidance,pull,bias,regulate,reputation,in,credit,determine,persuade,force,shape,power,prestige,pressure,prompt,effect,impact,guide,manipulate,prejudice,affect,juice,impress,control,significance
 principles	assumption,elements,doctrine,convention,foundation,basis,rule,fundamentals,philosophy,alphabet,regulation,basics,grammar,fundamental,proposition,law,essentials,truth
 lovers	collectors,nuts,girlfriend,sweetheart,bugs,supporters,enthusiasts,fools,companion,friends,boyfriend,fans,freaks
-gibson	
 pike	drag,row,road,artery,route,way,boulevard,lane,street,avenue,interstate,roadway,highway,pass,arterial,freeway,drive
 enhanced	stressed,new,terrible,revised,rich,exquisite,acute,decorated,other,intense,explosive,upgraded,higher,profound,loud,further,concentrated,emphasized,intensive,also,ringing,extra
 crossover	vital,crucial,watershed,deciding,highest,decisive,crossing,high,critical,meridian,path
@@ -12159,7 +11484,6 @@ bush	horrible,lilac,deficient,terrible,coca,cotton,short,inadequate,punk,rose,ju
 dvd	tape,video,videotape
 fcc	independence,free,autonomous,indie,individual,separate
 survive	remain,weather,suffer,sustain,endure,live,be,bear,last,thrive,go,recover,withstand,keep,persist,continue,exist,handle
-acetate	
 punished	condemned,dismissed,corrected,charged,fined,assessed,convicted,criticized,imposed,sentenced
 trading	traffic,dealing,exchange,purchasing,bargaining,negotiating,commerce,dealings,transaction,swapping,industry,trafficking,buying,market,deal,sales,manufacturing,selling,trade
 advisory	counseling,exemplary,warning,assisting,counselling,consulting,informative
@@ -12172,12 +11496,10 @@ satisfies	entertain,convince,assure,provide,delight,meet,do,reward,accomplish
 physiology	biology
 communities	residents,state,cities,public,villages,neighborhoods,company,association,center,people,societies,society,district,nation,towns,neighborhood
 numeric	integer,digit,figure,symbol,decimal,numerical,number
-pulmonary	
 butterflies	horror,tension,turbulence,concern,careful,doubt,dread,uncertain,excitement,anger,terror,worry,stress,alarm,concerned,suspense,sensitivity,distressed,uncertainty,nerves,scared,panic,suspicious,misery,trouble,anxious,nervous,suffering,afraid,shakes,restless
 input	proposal,opinion,lesson,improvement,signaling,increment,increase,judgment,evidence,remark,observation,mention,help,signal,word,suggestion,encouragement,instruction,testimony,view,addition,goods,tip,warning,guidance,news,recommendation,report,aid,gain,review,load,prescription,picture,consultation,statistics,grant,intake,discussion,commentary,criticism,info,information,donation,note,knowledge
 departmental	commanding,bureau,supervisory,branch,regulatory,agency,service,office,division,governmental,organizational,ministerial,desk,managerial,legislative
 redwood	wood
-behind	
 god	religious
 visualization	imagery,consciousness,conception,insight,judgment,vision,idea,thought,enlightenment,wit,comprehension,fancy,resolve,awareness,absorption,intelligence,decision,uptake,perception,inspiration,understanding,digestion,realization,fantasy,image,imagination
 jokes	stunt,tricks,gag,comedies,ribs,cracks,humor,parody,laughs,laugh,trick
@@ -12225,13 +11547,11 @@ treasure	worship,trophy,wealth,glory,cash,reserve,money,prize,gold,preserve,fort
 rise	jump,build,double,begin,lift,increment,increase,boom,growth,rocket,bubble,boost,come,surge,happen,acceleration,hike,travel,steam,move,inflation,progress,mushroom,advance,balloon,emerge,accumulate,improve,swell,gain,climb,wax,develop,mount,go,soar,spread,raise,rising,grow,zoom,arise,occur,multiply,accelerate,expand
 protect	hold,guard,save,support,prevent,ward,cushion,secure,insure,keep,safeguard,preserve,assure,shelter,conserve,defend,surround,fence,cover,screen,charm,shield,wall
 toledo	blade
-anna	
 tables	counters,boards
 concession	privilege,grant,admission,agreement,accommodation,permit,bargain,consensus,contract,deal,negotiation,compromise,franchise
 yankee	federal,north,american
 modal	average
 sight	eye,appearance,perception,view,company,presence,scene,vision,proximity,parade,display
-economist	
 working	engaged,going,active,on,operative,operating,live,busy,running,functioning,operational,employed,alive,living,functional
 instant	second,mo,minute,wink,immediate,moment,rapid,bit,flash,heartbeat
 reluctant	skeptical,slow,cautious,shy,unwilling,unsure,afraid,uncertain
@@ -12252,12 +11572,9 @@ name	announce,designate,cite,designation,personality,identify,mention,nickname,s
 assignment	post,homework,guard,appointment,commission,fatigue,duty,practice,job,choice,selection,mission,task,project,allocation,nomination,position,distribution,charge,drill
 schema	representation
 northwest	northwestern,north
-est	
 tourists	visitors,visitor,traveler,travellers,travelers
-weber	
 deduction	rebate,exemption,depreciation,allowance,reduction,credit,discount,abatement
 aviation	aggregation,accumulation,flight,navigation,collection,flying
-bosnia	
 clip	blow,licking,slam,beating,hit,cut,spank,buffet,pick,crack,bat,smash,lick,slug,punch,rap,slap,plump,cuff,trim,shear,belt,bash,shave,bang,stripe,bop,box,nip,bust,stroke,swing,kick,switch,hack,sock,hand,knee,pound,knock,hook,chop,dab,beat,pounding
 decimal	integer,statistic,digit,sum,fraction,figure,total,numeric,number
 shipment	merchandise,purchase,bundle,product,draft,shipping,weight,goods,delivery,burden,packet,transportation,load,parcel,haul,freight,package,pack,cargo,loading,payload,ware
@@ -12267,7 +11584,6 @@ latter	lag,concluding,ultimate,eventual,mormon,last,following,lowest,protestant,
 updated	modified,recent,happening,last,stylish,corrected,improved,latest,cooked,transformed,now,adjusted,amended
 snack	bite,lunch,chew,tea,meal,bit,taste
 contra	against,anti,contrary
-dishwasher	
 registered	recorded,listed,certified
 midget	tiny,mini,little,scrub,petite,dwarf,miniature,shrimp,small
 permanent	continuous,enduring,endless,perpetual,persistent,standing,immortal,durable,eternal,stable,lasting,everlasting
@@ -12303,7 +11619,6 @@ accumulate	jump,assemble,increase,gather,concentrate,collect,rise,acquire,mushro
 lame	ineffective,nasty,cheap,sorry,dirty,mean,game,halt,weak
 rebuilt	repaired,fixed
 plane	aircraft,wing,pod,fighter,jet,bomber,gas,throttle,ship,gun,windshield,airplane,hood,accelerator,craft
-hunters	
 backed	endorsed,favored,embraced,helped,approved,adopted,assisted,supported
 seven	cardinal
 assembly	congregation,symposium,caucus,gathering,machine,market,panel,audience,crowd,house,conference,meeting
@@ -12332,16 +11647,13 @@ routines	practices,techniques,traditions,habits,approaches,programs,procedures,p
 support	backing,sustain,promote,prop,hold,protection,stay,responsibility,help,finance,loyalty,pillar,boost,foundation,payment,encouragement,approve,mounting,encourage,stand,relief,maintain,continue,abide,fund,sponsor,assist,spur,tolerate,aid,back,bear,column,establish,reinforce,bracket,carry,mount,pole,raise,care,assistance,justify,shore,arch,strengthen,reinforcement,take,brace,subsidy,endorse
 veto	injunction,reject,refuse,vote,ballot,ban,deny,warning,restriction,denial,objection,prohibition
 dba	name
-xi	
 sponsored	endorsed,financed,recommended,favored,funded,approved,settled,assisted,backed,supported
 require	instruct,cause,order,involve,expect,demand,draw,need,exact,request,cost,govern,warrant,take,want,claim,challenge,ask
 backpack	pack,handbag
 hang	execute,hold,bend,sling,pin,decorate,flap,stretch,tack,string,drop,suspend,mount,lean,swing,remain,wave,cover,beetle,hook,stick,drift,float,attach
 lowered	discounted,inexpensive,competitive,downward,down,economical,reasonable
 microscopic	tiny,micro,little,wee,negligible,miniature,small,invisible,atomic
-maldives	
 cycling	athletics
-islamic	
 commenced	modern,began,created,ongoing,contemporary,launched,initiated,opened,started
 babes	cubs,recruits,students,beginners,freshmen,colts,newbies,newcomers,virgins
 goodwill	grace,fellowship,friendship,community,harmony,kindness,generosity,brotherhood,charity
@@ -12352,7 +11664,6 @@ capable	qualified,accomplished,fit,good,efficient,equal,intelligent,talented,gif
 inequalities	variation,friction,conflict,discrimination,distance,disagreement,contrast,difference,injustice,diversity,bias,distinction
 john	toilet,convenience,stool,throne,pot,room,bath,can,head,closet,bathroom
 playing	sporting,resting,lax,pleasing,easy,piping,relaxing,rendering,fast,entertaining,hanging,amusing
-taylor	
 jungle	accumulation,tumble,combination,medley,salad,hash,litter,clutter,stew,forest,assortment,blend,wood,variety,shuffle,collage,motley
 missing	removed,wanting,away,gone,lost,absent,forgotten
 bargains	deals,steals,buys,bonuses,gifts
@@ -12360,7 +11671,6 @@ commented	disclose,observed,reflect,assert,say,explain,notice,observe,noted,conc
 abit	relatively,slightly,moderately,enough,like,somewhat,fairly,rather,something,quite,kindly,pretty
 sheds	scales,slips,scraps
 services	blessings,privileges,onset,ritual,advantages,graduation,benefits,licences,burial,initiation,rite,favors,employment
-ninth	
 narrator	chart,writer,relate,report,speaker,chronicle,detail,describe,tell,teller,voice,author
 computerized	automatic,automated,digital,mechanical,robotic,motorized
 seats	orchestra,way,centers,commands,stall,seat,seating,circle,headquarters,room,homes
@@ -12386,8 +11696,6 @@ um	insertion,shout,cry
 puts	fixes,plants,sticks,sets,establishes,places,positions,lays,deposits
 recognizes	knows,sees,allow,realize,remember,makes,observe,perceive,registers,gets,senses,understands,admit,notice,sanction,catches,agree,grant,respect,know,honor,see,note,make,appreciate
 spine	backbone,bone,back
-collins	
-ross	
 tall	hard,great,soaring,long,prominent,high,large,steep,big,dominant,height
 dead	doomed,dying,fallen,departed,vitality,cold,murdered,boring,wooden,asleep,gone,low,flat,living,deceased,life,executed,buried,late
 truth	integrity,correctness,faith,revelation,certainty,principle,credibility,legitimacy,fact,reliability,accuracy,realism,authenticity
@@ -12412,7 +11720,6 @@ tues	tuesday
 singular	unique,striking,remarkable,rare,noticeable,uncommon,incredible,odd,unusual,abnormal,extraordinary,strange,unprecedented,exceptional,outstanding,bizarre,particular,peculiar,exceeding
 resign	waive,deny,surrender,quit
 combining	combination,linking,integration,connection,coupling,mixing,union,blend,mix,consolidation,confusion,blending,merger,mixture,synthesis,merging,fusion,connecting
-slovak	
 named	specified,known
 revolt	conflict,rebellion,battle,outbreak,revolution,rising
 hurley	row,storm,hurricane,hurry,clutter,stew,noise,disturbance,coil,bother,zoo,stir,fun
@@ -12428,7 +11735,6 @@ inspiring	exciting,fascinating,breathtaking,electric,moving,encouraging,intrigui
 models	form,pattern,reproductions,portrait,configuration,copies,design,copy,painting,figure,wear,style,photograph,create,ideal,original,prototype,miniatures,picture,mode,represent,variety,image,kind,symbol,type
 menace	hazard,plague,threaten,risk,danger,threat
 leisure	convenience,recreation,resting,ease,vacation,rest,silence,holiday,relaxation,sleep
-immunology	
 comics	cards
 plug	seal,stop,stuff,closure,pack,fill,dam,block,cork
 saint	babe,newbie,god,sheep,pigeon,angel,lamb,virgin,immortal,innocent,colt,cub
@@ -12439,11 +11745,9 @@ enlarge	build,increase,boost,extend,rise,mushroom,balloon,accumulate,swell,gain,
 courage	heart,determination,spirit,virtue,daring,guts,brave,endurance,nerve
 amusing	exciting,engaging,funny,nice,enjoyable,pleasant,humorous,delightful,comic,interesting,entertaining,charming,lively,pleasing,fun
 eliminated	banned,barred,prohibited,prevented,suspended,excluded,detached
-epstein	
 pavilion	kiosk,casino,tent
 disregard	negligence,cut,forget,contempt,omit,ignore,neglect,handle
 consisting	according,going,sorting,fitting,corresponding,conforming,checking,answering,dwell,agreeing,matching
-vanuatu	
 requirement	necessity,requisite,must,demand,essential,concern,prerequisite,qualification,specification,provision,necessary,obligation,duty,responsibility,condition,need
 over	concluded,ended,complete,upstairs,too,more,ever,terminated,off,above
 humor	content,enjoyment,amusement,comedy,personality,humour,joke,nature,cartoon,wit,play,comic,message,sketch,irony,satire,mot,tone,laugh,fun,bite,character,gag,imitation,substance,sport
@@ -12451,7 +11755,6 @@ faint	obscure,dull,soft,pale,dim,weak,delicate,opaque,vague,slight,dark,unclear,
 toilette	dressing,grooming
 bazaar	store,shop,market,showroom,mart,emporium,shoppe,outlet,marketplace
 shake	fan,upset,wave,quake,rock,slash,worry,jerk,toss,move,undermine,bucket,throw,swing
-hawks	
 synonym	analog,copy,counterpart,analogue,duplicate,replica
 concerning	respecting,of,touching,on,towards,toward,about,regarding
 parliamentary	congressional,regulatory,supervisory,executive,governmental,ministerial,official,managerial,administrative
@@ -12466,10 +11769,8 @@ herd	flock,mob,sheep,drove,horde,cows,cattle
 minors	boys,adolescents,youths,league,teenagers,kids,conference
 shear	shave,poll,crop,bob,nip,cut,dress,clip,dock,trim
 started	jumped
-prima	
 bash	blow,licking,slam,beating,hit,spank,buffet,pick,crack,bat,smash,lick,slug,punch,rap,slap,plump,cuff,belt,bump,bang,stripe,bop,box,bust,stroke,swing,kick,switch,hack,sock,knee,pound,knock,hook,chop,clip,dab,beat,pounding
 celebration	party,affair,carnival,jubilee,anniversary,occasion,performance,fest,function,fiesta,triumph,birthday,ceremony,bash,gala,festival
-tau	
 add	combine,insert,tag,increase,boost,string,append,extend,continue,button,reply,supply,enhance,modify,mix,complement,reinforce,qualify,include,tie,compound,stud,mark,annex,milk,multiply,fix,expand,introduce,supplement,attach
 lease	development,hire,rent,property,lot,plat,undertake,plot,parcel,charter,tract
 possess	have,exhibit,retain,hold,occupy,enjoy,maintain,carry,own,feature,seize,acquire
@@ -12496,8 +11797,6 @@ compilation	anthology,collection,assortment,album,reader
 monophonic	continual,mono,perpetual,regular,steady,consistent,stable
 positioned	planted,put,placed,set,based,fixed,laid,disposed,settled,parked,deposited,stuck,arranged,located,situated
 celebrity	name,somebody,star,hero,lion,someone,notable,popularity,immortal,personality,figure,light,superstar,celeb,icon,toast,vip
-upstairs	
-phd	
 listener	hear,audience,observer,attend,auditor
 appearances	opportunity,aspects,possibility,regards,shapes,figures,expectation,attitudes,looks,prospect,risk,forecast,behaviors,chance,dresses,persons,manners
 inventions	products,creations,innovations,works,devices,gadgets
@@ -12519,19 +11818,15 @@ sleep	bed,resting,bundle,rest,trance,coma,relax,nap,dreaming,dream
 dragged	dull,unhappy,earnest,down,troubled,sorry,depressed,sad,dark,miserable,carried,grim,serious,ugly,drew,anxious,bad,sober,pulled
 legal	contractual,constitutional,statutory,lawful,authorized,valid,regulation,legitimate,proper,fair,judicial
 tonga	gig,rig,diligence,coach,trap,tandem,surrey,victoria,coupe,stage,carriage,cab,buggy
-reagan	
 agency	authority,firm,service,office,company,gao,ins,fha,nist,nsw,organ,ds,bureau,army,phs,division,force,department,navy,usa,osha,gpo,operation,ai,branch,cdc,desk,nih,faa,irs,fda
 suffered	experience,sustain,witnessed,feel,saw,support,have,endure,encountered,bleed,knew,get,undergo,felt,experienced,receive,had,know,see,hurt,sustained,take,encounter,accept
 pouring	wet,running,rainy
-bangalore	
 appliances	tools,instruments,mechanisms,accessories,innovations,furnishings,machinery,apparatus,gadgets,widgets,material,inventions,utensils,furniture,plumbing,housewares
 indemnity	damages,punishment,reimbursement,repayment,shelter,compensation,insurance,satisfaction,remuneration
 dirty	foul,coarse,stained,buggy,muddy,chaotic,contaminated,filthy,nasty,dusty,black,messy
 tenerife	atlantic
 seas	roller,wave,surf,swell,surge,tsunami
-chico	
 brightness	illumination,glitter,blaze,light,sparkle,glow,shine,flash
-cummings	
 advisers	counselors,professionals,government,panel,department,ministry,committee,presidency,consultants,staff,experts,specialists,executive,university,personnel,jury,administration,cabinet,institute,bureau,authority,legislature,management,board
 effort	part,share,battle,training,creation,trial,work,intention,resolution,test,while,go,play,strain,batting,contribution,bid,squeeze,industry,liberation,run,striving,essay,shot,exercise,crack,force,try,pains,achievement,trouble,sweat,endeavor,push,power,activity,pass,attempt,worst,expenditure,offer,energy,stab,labor,struggle,best,endeavour,seeking,production
 deeper	other,profound,infinite,further,also,higher,extra,vast,new
@@ -12554,7 +11849,6 @@ tags	markers,plaques,labels,tickets
 globes	rings,spheres,beads,balls
 scared	anxious,worried,afraid,scary,nervous,shocked,upset
 mammalian	bodily,natural,coat,hair
-democrats	
 certainty	authority,unsure,sure,conviction,reality,certain,confidence,reliance,uncertain,trust,assurance,satisfaction
 penetration	discrimination,sense,brightness,wisdom,invasion,attack,sensitivity,appreciation,perception,grasp,intelligence,raid,intellect,comprehension,judgement,power,insight,breakthrough,understanding
 aye	constantly,forever,continually,often,always,consistently,ever
@@ -12562,7 +11856,6 @@ ladies	women,females,girls
 suite	tail,train,apartment,flat,lodging,crew,collection,following,rooms,personnel,rental,staff
 mark	stamp,illustrate,point,streak,ticket,value,designate,spot,record,register,qualify,signature,symbol,observe,tag,result,scar,impression,attend,imprint,indicate,marking,stain,impress,effect,demonstrate,line,characterize,differentiate,seal,identify,score,label,feature,show
 refresh	change,redesign,renew,repair,stimulate,restore,cool,recharge
-drake	
 charger	bowl,server,cup,disk,plate,casserole,disc,dish,tray
 shelves	freeze,waive,counter,rack,delays,suspend,waits
 mate	mount,bang,similarity,couple,twin,love,screw,ride,ruin,eff,pair,jazz,nick,know,half,roommate,breed,serve,bride,join,bed,cover,fellow,buddy,match,spouse,companion,service
@@ -12609,7 +11902,6 @@ fixture	component,symbol,icon,accessory,equipment,institution,device
 techniques	craft,methods,methodologies,approaches,recipes,styles,performance,system,capability,forms,procedure,facility,capacity,routine,manners,approach,style,tactics,systems,skill,strategies,plans,ways,manner,means,mode,art
 cigar	filler,smoke,corona
 colleges	boards,fellowships,chapters,societies,chambers,councils,leagues,groups,associations,communities,institutions,institutes,organizations,teams,clubs
-colon	
 fundamentally	essentially,inherently,basically
 cargo	payload,weight,loading,shipment,goods,freight,haul,product,draft,load,burden,ware,merchandise
 yearly	yearbook,reference,annually,regularly,weekly,daily,quarterly,monthly,annual,almanac
@@ -12617,17 +11909,14 @@ service	assistance,employment,work,waiver,advantage,favor,use,account,office,mai
 tone	resonance,fashion,quality,humor,vein,emphasis,expression,blend,tenor,nature,feel,strength,mood,accent,approach,shade,style,aspect,delivery,manner,mode,speech,note,trend,character
 bc	bc
 sliding	decreasing,stealing,lowering,descending,slippery
-resonance	
 indonesian	indonesia
 diagnostic	individual,distinguishing,proper,peculiar,distinctive,characteristic,general,classic,typical,distinct,identifying
-italic	
 rainfall	moisture,precipitation,storm,rain,torrent,shower,wet
 molded	tenacious,corrupted,shaped,integral,turned,solid,tight,wrought,stiff,hard,healthy,vigorous
 that	deeply,wicked,almighty,heavily,damned,particularly,too,sore,super,remarkably,badly,cracking,highly,who,ever,passing,severely,deadly,totally,really,completely,way,spanking,obviously,absolutely,seriously,much,extra,especially,right,full,extremely,far,jolly,real,very,positively,damn,so,fully,which,incredibly,specially,thoroughly,such,utterly,wholly,exceeding,greatly,awful,terribly,exceptionally,entirely,bone,most,significantly,mighty,desperately
 developing	improvement,innovative,continuing,robust,tender,contemporary,expansion,growing,evolving,breathing,modern,dynamic,uncertain,wealthy,increase,progress,rising,emerging,successful,unstable,lush,raw,evolution,proceeding,current,new,expanding,fresh,radical,spreading,viable,healthy,advancement
 knocking	crashing,knock,striking,hitting,smashing
 topic	point,field,motif,idea,proposition,issue,theme,content,material,argument,affair,essence,head,purpose,substance,problem,question,precedent,subject,case,motive,business,keynote,matter
-scooter	
 cousins	relations,families,relatives
 definite	precise,decisive,clear,obvious,decided,limited,restricted,defined,narrow,straightforward,specific,measured,positive,pronounced,distinct,finite,expressed,explicit,bold,certain,definitive
 urging	lobbying,persuasion,influencing,conversion,convincing
@@ -12638,13 +11927,11 @@ leaflet	bulletin,advertisement,brochure,folder,booklet,flap,circular,flyer
 analytical	logical,reasonable,scientific,investigative,coherent,valid,thorough,empirical,analytic,rational,detailed,cognitive,diagnostic,systematic,sensible,good,sound
 mistake	fault,trip,distortion,omission,stain,skip,error,slip,confusion,spot,oversight
 myths	lore,tales,legend,legends,belief,tradition,stories
-mips	
 circumstances	destiny,fortune,failure,chances,portions,lot,condition,providence,fate,accidents,portion
 brushed	stuffed,sleek,glazed,shining,glossy,silky,coated,polished,satin
 controllers	controls,regulators
 cessation	pause,suspension,offset,shutdown,cease,closure,stop,expiration,stay,conclusion,finish,termination,end,close,halt,interruption,separation,ending,arrest
 relocating	disturbing,shifting,removing,transporting,replacing,moving,transferring,carrying
-czech	
 mill	shop,plant,foundry,workshop,works,factory,line
 feasible	reasonable,beneficial,suitable,worthwhile,available,executable,profitable,viable,possible,practicable,likely,practical,appropriate
 among	between,midst,through,amid,mid
@@ -12687,7 +11974,6 @@ pesos	fund,lettuce,wealth,cabbage,property,cash,pay,bill,salary,capital,payment,
 genres	kind,classes,stripes,types,fashion,descriptions,breeds,category,brand,manners,categories,style,sorts,strains,kinds,character,varieties,species
 viewpoints	minds,angles,attitude,shoes,outlook,direction,perspective,standpoint,views,stance,angle,posture,view,aspect,opinions,feelings,perspectives
 stain	marble,tar,poison,touch,dirty,dye,vein,color,soil,dip,mar
-commanders	
 fonts	springs,wells,roots,fountains,beginnings,origins,sources
 circumstance	fortune,chance,luck,crisis,factor,fate,coincidence,destiny,cause,time,accident,status,event,occurrence,action,thing,detail,doom,case,incident,fact,condition,matter,portion
 iq	ratio,command,iq,experience,proficiency,mastery
@@ -12735,7 +12021,6 @@ trainee	pupil,freshman,candidate,learner,newbie,cadet,student,novice,beginner,re
 martini	gin
 cambodia	asean
 alias	surname,nickname
-hitler	
 adrenaline	endocrine
 nepal	asia,everest
 traded	sold,purchased,negotiated,dealt,exchanged,bought
@@ -12746,7 +12031,6 @@ hanover	deutschland,germany
 resume	preserve,restart,renew,continue
 desired	appreciated,proper,convenient,useful,favored,appropriate,desirable,wanted,satisfying,required,welcome,true,beloved,fitting,correct,decent,popular,apt,pleasing,vital,essential,pleasant,main,legitimate,pertinent,relevant,good,refreshing,necessary,applicable
 vent	air,chimney,release,loose,duct,voice,pipe,express,utter,show
-invasive	
 stations	jobs,positions,devotion,quarters,operations,posts
 fraud	scam,offense,crime,offence,rig,sting,con,scheme
 carcinoma	disease,tumor,swelling,corruption,melanoma,mesothelioma,cancer,lymphoma,sickness,lump
@@ -12762,7 +12046,6 @@ thigh	pin,hip,shin,quad,leg,ham,limb,calf
 actresses	performers,stars,list,players,actors
 masterpiece	gem,jewel,monument,classic,success,treasure
 car	fender,window,wing,sedan,racer,coach,reverse,cruiser,horn,gas,heap,machine,hood,taxi,wheels,ride,throttle,fin,saloon,accelerator,motor,jeep,gun,cab,coupe,low,trunk,truck,grille,ambulance,pickup,auto,electric,buffer,suv,van,hatchback,limo,third,bus,automobile,convertible,compact,bumper,high,first,limousine,hack,roof,wagon
-thrillers	
 booked	charged,engaged,contracted,reserved,hired
 tanner	beige
 hotspot	base,kernel,core,seat,hub,nucleus,focus,thick,playground,nexus,headquarters,central,center,essence,heart,capital,axis,locus
@@ -12811,14 +12094,12 @@ nevada	southwest,usa,us,nv,colorado,america,reno
 seasons	fall,period,spans,spells,days,minutes,shakes,moments,ages,space,winter,summer,stretches,intervals,seconds,time
 socially	culturally,politically
 mojo	poison,symbol,fetish,drug,coke,emblem,magic,crack,charm
-evanescence	
 cook	warp,obscure,fudge,twist,color,bend
 phosphate	salt
 hamburg	germany
 industrial	technical,mechanical,fabricated,manufactured,synthetic,modern,developed,cultivated,artificial
 cloudy	dim,overcast,misty,dull,opaque,muddy,dark,dense
 gland	organ,endocrine
-lister	
 cute	subtle,slick,shady,fraudulent,beautiful,precious,designing,adorable,calculating,tricky,delightful,crooked,pretty,slippery,sharp,charming,pleasant
 courier	traveller,traveler,herald,mule,runner,messenger
 nausea	symptom,vomiting,sickness
@@ -12831,7 +12112,6 @@ pitbull	shark,fighter,tiger
 photographer	artist,shooter
 nicely	correctly,accurately,well,wonderfully,great,finely,beautifully,perfectly,happily
 brazilian	brasil
-hebrew	
 pimp	offender,cadet
 phs	authority,agency,hhs,office,bureau
 drowning	flooding,overwhelming,flushing,overcoming
@@ -12924,7 +12204,6 @@ saskatoon	saskatoon,bush
 stimulus	impulse,catalyst,induction,input,momentum,cue,stimulation,spur,encouragement,motivation,kick,reason,information,fuel,boost,reinforcement,incentive,yeast
 constitutional	legal,lawful,fundamental,natural,democratic,constituent,integral,inner,internal,intrinsic,walk,inherent,essential,native,statutory,organic,congenital,indigenous,inherited,elemental,basic,distinctive
 supervised	ordered,overlooked,headed,guided,directed,administered,commanded,run,controlled,ran,managed,handled,monitored
-projector	
 oppose	deny,fight,dispute,disagree,prevent,face,resist,protest,contest,debate,argue,withstand,fence,attack
 mirror	illustrate,echo,follow,glass,represent,reflector
 mpeg	encoding,mpeg,encryption
@@ -12983,7 +12262,6 @@ shaving	part,hunk,chunk,sample,segment,taste,splinter,dose,item,slice,chop,trace
 pros	professionals,specialists,enthusiasts,fans,consultants
 diagrams	pictures,figures,plates,drawings,graphics,representations,illustrations,portraits,images
 fantasy	imagination,dream,fancy,vision,fiction,nightmare,illusion,idea,mirage
-med	
 baht	beat,bang,blow,hand,clip,lick,hit,rap,belt,switch,spank,knee,stripe,sock,smash,licking,slam,swing,pick,crack,buffet,pounding,punch,chop,stroke,slug,cuff,box,dab,pound,bash,kick,plump,knock,bust,hook,hack,bop,slap
 throughput	output,turnout,production
 moving	dramatic,inspirational,automotive,meaningful,affecting,changing,restless,blown,stunning,touching,emotional,impressive,exciting,shifting,motion,feeling,flying,mobile,inspiring,expressive,stirring,kinetic,passionate
@@ -12998,7 +12276,6 @@ face	air,fight,present,margin,mask,experience,neighbor,risk,look,oppose,bound,ch
 candy	enhance,spruce,sweet,patty,kiss,trick,improve,fudge,rock,mint
 dietary	enriched,nutrient,beneficial,nutritional
 affiliated	allied,akin,associated,comparable,attached,related,connected
-japanese	
 regards	sees,sights,watches,notes,notices,considers,eyes,remarks,views,spies,catches,witnesses,spots
 obesity	fat,weight,overweight
 outs	reveals,tells,breaks,spreads
@@ -13021,7 +12298,6 @@ advance	gain,raise,grant,upgrade,growth,further,hike,advancement,grow,rise,speed
 pant	puff,blow
 customise	build,change,construct,alter,customize,modify
 neighbors	people,birds,customers,brothers,friend,men,individuals,celebrities,parties,personalities,humans,fellows,guys,brethren,things
-ceo	
 abstraction	observation,concept,construct,impression,conception,image,absolute,thought,picture,teacher,perception,right,reflection,idea,thing,theory,notion
 retardation	decline,drop,change,retreat,slowing,modification
 fossil	tory,skeleton,conservative,trace,specimen,remains,veteran
@@ -13035,7 +12311,6 @@ tights	pantyhose
 crescent	curve
 extensively	greatly,much,considerably,utterly,largely,significantly,highly,broadly
 correlation	correspondence,relationship,equivalence,similarity,equation,interaction,parallel
-theological	
 cane	club,hammer,rod,billy,baton,bat,pole,staff
 openness	honesty,simplicity
 lasts	remains,goes,continues
@@ -13045,7 +12320,6 @@ trustees	chamber,jury,panel,commission,cabinet,board,committee,bureau
 biology	morphology,anthropology,botany,genetics,physiology,zoology,ecology,forestry,medicine
 friendly	sweet,intimate,sympathetic,beneficial,favorable,social,loyal,helpful,cozy,nice,loving,informal,merry,familiar,good,welcoming,peaceful,warm
 customized	tailored,custom,specialized,personalized
-steak	
 stevens	precedent,aggregation,collection,accumulation
 freshmen	beginners,colts,cubs,students,newbies,newcomers,recruits,virgins
 instinct	impulse,competence,sense,urge,affinity,capability,turn,intuition,facility,feeling,savvy,skill,talent,proficiency,disposition,power,need,sentiment,bias,drive,tendency
@@ -13055,7 +12329,6 @@ faces	air,fight,mask,experience,risk,look,meets,oppose,cheek,take,neighbors,chal
 precise	accurate,decisive,proper,microscopic,refined,rigorous,delicate,fine,mathematical,literal,definite,rigid,narrow,very,dead,strict,correct,nice,particular,specific,exact,actual,distinct,close,explicit,careful,formal
 nw	point,northwest
 tricky	sticky,complex,smooth,problematic,delicate,nasty,serious,subtle,slick,complicated,tough,slippery,unstable,rocky,hard,problem,hairy,painful,sensitive,critical,risky,difficult
-aaron	
 engine	diesel,train,transformer,converter,gear,machine,weapon,generator,tool,appliance,instrument,motor,turbine
 divide	paragraph,part,share,disconnect,initialize,format,cut,lot,break,split,divorce,arrange,tear,partition,shift,pull,vary,splinter,isolate,parcel,resolve,separate,slice,differ,canton
 worldwide	blanket,collective,planetary,overall,broad,wide,universal,comprehensive,generic,general,international,global,multinational,widespread,extensive
@@ -13072,7 +12345,6 @@ wig	switch,rug
 cuz	cousin,mate,aide,colleague,buddy,assistant,protector,nurse,partner,ally,associate,guide
 niagara	waterfall,blizzard,bath,avalanche,tide,stream,flood,overflow,torrent,river
 barley	turf,hay,corn,meadow,pasture,food,cereal,meal,grain
-algae	
 belonging	familiarity,affinity,affection,friendship,love,happiness
 safari	journey,campaign,outing,progress,voyage,odyssey,trip,expedition,flight,excursion,tour,quest,trek,cruise
 groom	educate,lay,tend,arrange,fit,furnish,fix,ready,prepare,comb,equip,provide,prep,participant
@@ -13089,7 +12361,6 @@ nursing	treating,care,attention,preserving,healing,supporting,aid
 certain	unnamed,precise,various,absolute,genuine,clear,unspecified,some,definite,confidence,true,specified,anonymous,real,certainty,individual,special,convinced,one,unidentified,particular,specific,safe,positive,authority,sure,numerous,confident
 colonial	resident,colony,social,settlement,dependent
 uptake	conception,sense,saturation,awareness,consumption,retention,suction,appreciation,sucking,swallow,digestion,drinking,perception,grasp,intelligence,drink,comprehension,penetration,judgment,eating,insight,activity,realization,knowledge,recognition,understanding,absorption,intake,feeding
-sydney	
 lakeside	shoreline,sand,coast,formation,waterfront,border,beach,bank,strand,shore,lakeside
 private	intimate,individual,special,close,separate,quiet,exclusive,undercover,hidden,restricted,inside,secret,backstage,independent,classified,confidential,personal
 reviewing	amending
@@ -13128,7 +12399,6 @@ head	direct,lead,creature,officer,bean,brain,animal,dome,guide,beast,temple,dire
 atom	patch,drop,scrap,nucleus,molecule,bite,radical,fraction,bit,substance,lick,trace,element,particle,grain,fragment,portion
 transformers	machines,engines,motors,mechanisms,appliances,converters,mills
 subset	subdivision,subgroup
-cowboys	
 going	prevalent,usual,stock,average,conventional,dependable,popular,standard,customary,prevailing,current,normal
 defending	garrison,keeping,saving,lining,securing,hostile,disputed,anti,covering,preventing,opposing,padding,protecting
 absurd	incredible,wacky,ridiculous,weird,insane,foolish,bizarre,crazy,curious,funny,fantastic,peculiar,strange,silly,unreal,unreasonable,stupid,wild,odd
@@ -13136,9 +12406,7 @@ elite	chosen,cream,wonderful,establishment,superb,superior,premium,exclusive,gre
 blazer	jacket,coat
 confirms	approve,endorse,establish,explain,back,argues,certify,sign,proves,assure,verify,support,affirm,supports,witnesses,demonstrates
 dresser	secretary,wardrobe,chest,shelf,console,showcase,drawer,closet,cabinet,buffet,shelving,bureau
-darwin	
 loser	lemon,mess,miss,failure,flop,bust,frost,disaster,turkey,bomb,disappointment
-insurer	
 tagged	marked,labelled,stamped,labeled,designated,identified
 vineyards	farms,gardens,estates
 morgan	mount
@@ -13161,7 +12429,6 @@ noting	saying,reflecting,stating,observing,commenting
 bombing	descent,assault,strike,invasion,onset,offense,offence,rush,attempt,charge,blitz,offensive,aggression,attack,raid
 tucker	bladder,pouch,sap,sack,bread,drain,provisions,jade,dish,supplies,envelope,chuck,skin,faint,rot,disable,tote,meat,weary,fatigue,container,fail,food,fare,table,exhaust,backpack,eats,meal,purse,suffer,chow
 performance	adaptation,work,presentation,finale,act,bit,conduct,display,spectacular,dance,variation,version,rendering,practice,play,operation,opera,premiere,account,achievement,turn,number,appearance,theatrical,action,interpretation,concert,drama,representation,benefit,reading,behavior,production,show
-firmware	
 ate	chew,feed,swallow,drain,dine,consumed,pick,bite,attack
 theology	communion,religion,philosophy,field,doctrine,law,faith,cult,church,discipline,theory,sect,gospel,belief,ideology,creed,study,subject
 attendant	helper,accompanying,loader,tender,second,custodian,checker,aide,page,batman,assistant,servant,help,nurse,supporter,companion,rocker
@@ -13192,14 +12459,12 @@ householder	homeowner,saver,somebody,holder,individual,someone,person,soul,owner
 initiatives	leadership,hustle,spirit,enterprise,energy,action,drive,push,go,ambition
 lamb	hog,sheep,dove,colt,innocent,saint,angel
 directors	presidents,panel,department,ministry,administrators,committee,presidency,executives,managers,executive,supervisors,jury,commissioners,administration,cabinet,officers,bureau,authority,legislature,management,board
-sac	
 examining	pumping,questioning,trial,examination,test,measurement,verification,interested
 reclamation	recovery,rehabilitation,restoration,rescue,renewal,retrieval
 subs	heroes
 rails	road,highway,runway,railroad,trail,lane,course,track,route,railway,siding,fence,pole,barrier,rail,roadway,line,street,bar
 shady	covered,cloudy,dim,questionable,shaded,crooked,slippery,dark
 spun	wheeled,rolled,twisted,turned
-unicef	
 faded	pale,white,dim,grey,pastel,light,worn,dull,neutral,gray,faint
 mold	construct,forge,dirt,gravel,work,mud,sand,model,shape,dust,earth,form,clay,soil,ground
 colleague	friend,aide,fellow,buddy,assistant,pal,peer,partner,ally,associate,companion
@@ -13210,7 +12475,6 @@ boxed	struck,kicked,tapped,stamped,cracked,chopped,enclosed,pushed,busted,hit,ta
 accelerator	gas,car,machine,pedal,airplane,plane,auto,gun,automobile
 wrath	madness,irritation,mood,contempt,anger,fury,mad,ire,rage
 bite	zip,chew,eat,severity,taste,cut,nip,edge,burn,snap,spice,grip,sting,punch,ginger,wound,tang
-amber	
 rehabilitation	recovery,improvement,restoration,reconstruction,repair,rehab,healing,comeback,overhaul,reclamation
 sour	bitter,bother,rotten,turn,work,alien,unpleasant,biting,anger,split,divide,sharp,acid
 children	tribe,infants,babies,chicks,buds,folk,teenagers,teens,adolescents,people,household,kids,youths,monkeys,group,cubs,clan,toddlers,house
@@ -13230,7 +12494,6 @@ profit	surplus,part,earn,cleanup,income,output,harvest,gain,saving,killing,acqui
 steadily	commonly,regularly,inevitably,normally,continuously,always,often,constantly,repeatedly,frequently,consistently,routinely,continually,forever,usually,generally,typically
 amateur	backyard,somebody,someone,soul,individual,primitive,sunday,person
 warsaw	poland
-microscopy	
 mailing	forwarding,shipping,transmission,posting,addressing,transmitting
 tail	process,hound,flag,dock,rear,suite,staff,following,crew,train,brush,bottom,bob
 uncertainty	question,quality,confusion,concern,suspicion,worry,anxiety,doubt,trouble
@@ -13260,9 +12523,7 @@ transsexual	transexual
 housed	secured,lodged
 discounts	deductions,reductions,rebates
 incense	aroma,bother,perfume,odor,fragrance,balm,bouquet,scent,anger,spice,excite,compound
-np	
 errors	trips,omission,failure,sin,faults,bricks,fault,mistakes,flaw,inaccuracies,offense
-thunderbird	
 shops	stores,markets,outlets
 mn	minneapolis,duluth,rochester,america,usa,minnesota,virginia,midwest,us
 comprehension	grasp,appreciation,awareness,grip,understanding,perception
@@ -13282,7 +12543,6 @@ bibles	guides,textbooks,references,texts,manuals,dictionaries,readers
 putin	plant,drill,seed
 carefully	thoroughly,strictly,correctly,deliberately,precisely,fully
 bohemian	character,deviant,anomaly,maverick,freak
-berg	
 visa	warrant,authorization,endorsement,permit,sanction,permission,key,admission,proof,establishment,ticket,verification,testimony,charter,passing,approval,concession,patent,allowance,passport,license,acceptance,evidence,grant,recognition,consent,legislation,ratification,privilege,passage
 lineup	schedule,agenda,cleanup,organize,order,rank,slate,group,calendar,structure,record,system,marshal,roster,arrange,activate,marshall,rally,roll,business
 grip	bite,grasp,nip,bags,pinch,influence,handbag,control,seize,squeeze,luggage,clutch,briefcase,wallet,restraint,constraint,backpack
@@ -13303,7 +12563,6 @@ licking	finish,failure,whipping,lump,defeat,beating,loss,conclusion,waterloo,end
 certify	witness,affirm,authorize,approve,validate,demonstrate,notify,show,manifest,reflect,guarantee,assert,license,ascertain,evidence,endorse,verify,confirm,testify
 mum	silent,mute,dumb
 hitch	web,hazard,interruption,attach,surprise,risk,catch
-fischer	
 nylons	stocking
 temperatures	climate,warmth,cold,heat,condition
 seeing	visual,optic,focusing,fusion,optical,perception
@@ -13316,7 +12575,6 @@ sinks	falls,declines
 ram	crash,smash,slam,knock,strike,thrust,bang,pound,impact,sink,hit,stab,bash,bump
 inspections	scans,analyses,checks,examinations,audits,investigations,views,reviews,surveys
 fungi	kingdom
-evans	
 camel	cream,tan
 metro	experienced,railway,seasoned,underground,railroad,graceful,subway,cosmopolitan,polished,tube,cultured,poised,metropolitan,cultivated
 thermometer	instrument
@@ -13336,7 +12594,6 @@ understand	dig,grasp,register,translate,hear,insight,decide,guess,perceive,judge
 jesus	christ,savior
 prophet	mystic,visionary,witch,oracle
 hips	realization,informs,expiration,verses,achievement,advises,lectures,briefs,tells,accomplishment,integration,fulfillment,conclusion,clears,teaches
-bilingual	
 appetizers	snacks,bites,nuggets,tastes
 partitioning	splitting,zoning,separating,division,separation,subdivision,resolving,dividing,segmentation,partition,pulling
 outlets	exits,issues,escapes
@@ -13366,19 +12623,16 @@ sponge	dependent,drunk,wipe
 rode	annoyed,tested,tried,bothered,got
 administer	apply,extend,serve,deliver,deal,oversee,authorize,donate,execute,assign,divide,portion,care,supply,distribute,govern,provide,allocate,regulate,perform,impose,supervise,give,furnish,handle,direct,conduct
 rating	pricing,order,standing,rank,place,level,degree,ranking,score,valuation,status,situation,assessment,condition,appraisal,grade,mark,category,position,station
-quasi	
 dynamics	act,mechanics,gesture,passage
 challenging	demanding,painful,inspirational,analytical,tremendous,crucial,complex,offensive,tough,energetic,rugged,hard,killer,powerful,ambitious,visionary,rigorous,outrageous,disturbing,problematic,bold,heavy,rough,complicated,impressive,appealing,interesting,testing,inspiring,lively,tall,severe,difficult,exciting,serious
 dine	feast,feed,fare,consume,refresh,snack,eat,lunch
 athletic	healthy,trim,stout,tough,energetic,rugged,competitive,mighty,sound,powerful,muscular,active,coordinated,robust,vigorous,agile,strong,potent,flexible,recreational,husky,fit
-nero	
 collisions	contacts,crashes,blows,kicks,encounters,shocks,jars,strikes,impacts,hits
 ideas	images,thoughts,conversation,pictures,outlook,notions,creed,view,observations,assumptions,perceptions,theories,reflections,intelligence,philosophy,culture,impressions,concepts,information,beliefs,theory
 nursery	hub,capital,seat,preschool,nest,focus,base,center,seminary,nucleus
 synopsis	outline,abstract,recap,resume,roundup,inventory,summary,digest,brief
 leg	part,pin,knee,thigh,stage,body,pole,peg,ankle,lap,stick,limb,shin,foot,calf
 headquarters	home,capital,seat,command,office,center
-eta	
 influenced	convinced,affected,hostile,shaded,interested,concerned,distorted,colored
 precision	truth,fidelity,perfection,accuracy
 waterways	rivers
@@ -13388,7 +12642,6 @@ avant	advanced,progressive,underground,original,bizarre,contemporary,current,alt
 termination	cap,ending,completion,end,bound,barrier,limit,boundary,limitation,line,ceiling,expiry,extent
 observing	available,attending,participating,accompanying,present
 sesame	herb,benny
-therein	
 butcher	slaughter,kill
 cursor	missile,dart,pointer
 sail	drift,boat,steer,kayak,cruise,float,voyage,cross,coast,sweep,travel,navigate,leave,soar,fly,reach,shoot,yacht,move,ferry,run
@@ -13407,7 +12660,6 @@ preferences	favorites,advantage,priority,choice,weakness,option,pets,speeds,desi
 recruiting	selection,retaining,engaging,employing,lottery,paying,placing,hiring
 tribune	altar,stand,stage,platform,balcony
 spike	lance,spear,dart,pike,shoe,shaft
-bose	
 reimbursement	repayment,payment,paying,compensation,remuneration,rendering,allowance
 judges	moderators,tribunal,board
 factor	delegate,part,rf,aspect,influence,operative,element,sub,cause,replacement,proxy,circumstance,consideration,ambassador,point,deputy,substitute,parameter,ingredient,minister,representative,rep,fundamental,attorney,thing,agent,spokesperson,component,manager
@@ -13418,7 +12670,6 @@ translators	summarize
 deceased	corpse,dead,late,fallen,low,asleep,gone,dying,cold,departed
 everyone	somebody,anybody,all,someone,anyone,people,everybody
 chase	sack,tear,rush,tag,out,tail,pursue,trail,race,tree,hound,remove,trace,fire,quest,drive,hunt,dog,follow,dismiss,bounce,track
-timothy	
 living	existence,operative,running,live,operational,on,income,contemporary,job,working,operating,breathing,alive,functioning,going,experience,functional,active
 studying	researching,understanding,belief,thought,analyzing,reading,learning,opinion
 piracy	robbery,theft,copying,infringement
@@ -13467,7 +12718,6 @@ purchasing	taking,getting,shopping,purchase,buying
 articulated	choral,shouted,verbal,vocal,oral,articulate,pronounced,spoken
 shades	sunglasses,tones,glasses,specs,colors,polaroid
 cellphone	cell
-judicial	
 souvenirs	memorials,reminders,tokens,monuments
 inaccurate	outside,mistaken,invalid,wide,truth,incorrect,defective,wrong,accuracy,distorted,misleading,false,erroneous,away,faulty
 planted	drilled,constituted,scattered,established
@@ -13498,8 +12748,6 @@ linen	cloth,lingerie,textile,fabric,material,bedding
 hp	watt,hp,w
 greatest	unreal,first,top,breathtaking,capital,awesome,spectacular,notable,remarkable,noticeable,rare,terrific,distinguished,impressive,tops,great,noted,primary,highest,finest,satisfying,important,odd,key,prime,solid,elite,neat,significant,sovereign,best,glorious,incredible,chief,prominent,sheer,unique,uncommon,leading,popular,summit,wonderful,big,singular,exceptional,excellent,cardinal,strange,marvelous,curious,pinnacle,striking,apex,noteworthy,magnificent,stellar,exquisite,unprecedented,fantastic,enjoyable,superior,peak,famous,dominant,exclusive,valuable,surprising,foremost,super,perfect,main,fabulous,splendid,superb,central,supreme,attractive,ultimate,absolute,unbelievable,master,outrageous,pleasant,outstanding,eminent,special,height,major,principal,prior,paramount,premier
 construct	rebuild,organize,form,customize,formulate,make,found,design,lock,forge,compose,frame,manufacture,erect,build,shape,establish,raise,create,rear,fashion,customise,produce
-hindu	
-wetlands	
 dialogue	forum,conversation,dialog,consultation,consult,talking,communication,discourse,meeting,symposium,argument,discussion,conference,talk,debate,council,exchange,seminar,counsel
 chefs	cooks
 samson	bull,man
@@ -13511,7 +12759,6 @@ socks	hose,stockings
 finish	perfect,do,finale,polish,appearance,fulfill,complete,top,make,surface,end,execute,settle,accomplish,accomplishment,close,action,conclude,fulfil,spend,ending,terminate,improve,defeat,achieve,go,stop
 partners	side,spouses,brides,mates,company,lineup,unit,party,squad,wives,organization,husbands,club
 curse	spell,disaster,swear,burden,utter,ban,evil,express
-beethoven	
 strike	punch,try,feel,surprise,jar,experience,prompt,beat,force,knock,infect,take,touch,hit,catch,trouble,affect,crash,carry,stir,pierce,seize,upset,get,reach,walk,drive,attack,cloud,move,impress,motivate
 qualifier	applicant,intensive,entry,phrase,favorite,seeker,prospect,spoiler,candidate,hopeful,competitor
 satisfaction	content,delight,achievement,joy,comfort,enjoyment,amusement,pleasure,relief,fulfillment,happiness,pride
@@ -13521,13 +12768,10 @@ cruising	sightseeing,rowing,excursion,sailing,wandering,tour,driving,ride,shippi
 recommending	assigning,committing,passing,granting,submitting,transmitting,giving,delivering,transferring,distributing,leaving
 shares	interest,part,receive,contribution,experiences,division,split,participate,distribute,knows,divide,participates,proportion,percentage,dividend,stake,experience
 advert	brochure,hang,attend,announcement,bulletin,report,advertising,notice,posting,ad,advertisement,listen,release,notification
-wellington	
 scrub	rub,wash,mini,midget,mop,miniature,dwarf,shrimp,brush
 simulations	shadows,images,clones,impressions,fakes,reproductions,versions,dummies,miniatures,copies
 commanding	senior,primary,main,head,dominant,high,chief,first,imposing,impressive,foremost,supreme,lead,presiding,prime,premier,principal,top,compelling,leading,decisive
 tying	winding,wiring,binding
-eg	
-bart	
 perfume	aroma,incense,spice,balm,bouquet,otto,scent,oil,odor,fragrance,smell
 triumph	dominate,coup,pride,overcome,attainment,win,conclusion,slam,success,feat,achievement,miracle,waltz,joy,gain,sweep,ending,blowout,finish,fall,thrive,pin,prevail,victory,runaway,celebration,independence,conquer,accomplishment
 co	administrator,owner,head,government,company,corporation,chief,leader,manager,official,manufacturer,firm,officer,director,adjustment,ruler,organization,compliance,entrepreneur,supervisor,boss,commander,accession,executive,administration,management,captain,compatibility
@@ -13601,7 +12845,6 @@ cricket	fairness,decent,unbiased,justice,stable,reasonable,fair,honest,proper,eq
 cons	inmates,prisoners
 literacy	acquisition,skill,culture,learning,scholarship,accomplishment,attainment,proficiency,enlightenment,education,knowledge
 encountered	greeted,confronted,caught,faced,met
-starr	
 cared	minded,noticed,relaxed,satisfied,attended,watched
 explicit	specific,literal,straightforward,positive,expressed,obvious,definitive,certain,exhaustive,comprehensive,graphic,stated,correct,declared,complete,definite,specified,precise,open,full,express,accurate,clear,simple,exact
 deserve	get,earn,be,justify,merit,win,gain,warrant
@@ -13675,7 +12918,6 @@ incentive	motivation,impulse,reason,stimulus,encouragement,catalyst,momentum,boo
 cent	rand,bob,shilling,rupee,subunit,dollar
 hereinafter	hereafter
 intermediate	modest,gray,halfway,average,moderate,grey,typical,sophomore,reasonable,middle,medium,median
-from	
 medley	motley,variety,assortment,opus,blend,clutter,piece,jungle,hash,combination,composition,stew,accumulation,salad,collage,shuffle,litter
 lean	nod,list,slim,prop,tilt,sparse,twist,tend,angle,tip,pitch,cant,flex,angular,drift,slope,skinny,bend,bow,heel,prefer,slender,weather
 peacock	olive
@@ -13713,7 +12955,6 @@ marker	plaque,stone,ticket,caption,bookmark,pole,symbol,flag,indicator,label,tag
 arrangements	proposals,plans,strategies,games,schemes,systems,ideas,programs,ways,projects,designs,procedures
 desert	heath,wilderness,expose,lonely,maroon,quit,escape,waste,leave,abandon,wild,strand,arid,bolt,bush,flee,depart
 rushed	flying,rapid,rash,rush,spontaneous,sudden,quick,swift
-k	
 regiment	squad,command,division,wing,battalion,squadron,company,troop,detail,corps
 hun	jerry,german
 abnormal	unusual,unexpected,singular,rare,defective,exceeding,unique,peculiar,outstanding,deviant,irregular,uncommon,incredible,odd,remarkable,extraordinary,exceptional,noticeable,weird,strange,insane,bizarre
@@ -13721,7 +12962,6 @@ accidentally	randomly
 jelly	cake,freeze,set,gel,concrete
 fired	tossed,projected,threw,discharged,launched,unemployed,shot
 avon	england
-robin	
 launched	constituted,constructed,created,introduced,started,established,originated,began,planted,founded,initiated,organized
 missy	skirt,maiden,girl,gal,colleen,sheila,woman,belle,dame,doll,baby,chit,maid,sister,bird,miss,chick,babe
 replaces	substitutes
@@ -13731,16 +12971,13 @@ estate	palace,housing,ranch,property,penthouse,mansion,plantation,villa,holding,
 mentors	university,staff,instructors,advisors,advisers,tutors,department,teachers,managers,counselors,institute,personnel,guides
 pieces	debris,bits,fragments,wreck,residue,waste,fractions,scraps,trash,sediment,remains,junk,rubbish,portions,litter
 assure	encourage,secure,satisfy,guarantee,affirm,insure,comfort,ensure,make,doom,confirm,cheer,persuade,console
-stuart	
 extracted	detached,cited,removed,copied,pulled
 landmark	tree,highlight,milestone,position,watershed,museum,monument,memorial,marker,climax,corner
 imprint	track,trace,residual,shadow,trail,tread,indication,residue,reminder,scent,form,print,work,path,footprint,evidence,sign
 blends	cocktails,compounds,mixes,combinations,alloys,mixtures,composites
-qualifies	
 stole	jacket,mantle,cape,fur,wrap
 glory	fame,distinction,props,dignity,credit,majesty,prestige,sun,reputation,triumph,acclaim,praise,celebrity,applause,honor,tribute
 empire	corporation,land,domain
-leonardo	
 conquer	dominate,subordinate,silence,overcome,curb,defeat,wink,control,moderate,occupy,annex,contain,subject,check,hush,still,beat,burke,seize,reduce,suppress,achieve,crush,hold,inhibit
 sides	discourse,exchange,feet,conference,hands,conversation,scheme,communication,discussion,plot,foot,dialog,tops
 insist	announce,urge,claim,demand,declare,affirm,defend,maintain,assert,protest,press,request,confirm,hold,argue,repeat,warrant
@@ -13760,14 +12997,12 @@ pennsylvania	penn,usa,chester,pittsburgh,pa,harrisburg,america,us,philadelphia,b
 impotence	quality,inability,weakness
 briefings	judgments,lessons,information,instructions,alerts,warnings,considerations,sermons,thoughts,alarms,recommendations,solutions,data,feedback,observations,speeches,directions,lectures,teachings
 suites	tails,trains,crews
-nutrition	
 bottles	sauces,wines,drinks,spirits,juices,urn,jar,beers,glass
 erica	heath
 pap	provisions,meat,chuck,fare,mess,board,diet,food,feast,supplies,chow,bread,feed,plate,meal
 gratitude	thanks,recognition,acknowledgement,appreciation,obligation
 external	outer,irrelevant,outside,accidental,alien,position,exterior,foreign,unnecessary
 marking	labelling,figure,bar,streak,stamping,patch,pattern,blaze,stripe,identifying,spot,tagging,labeling,mark,design
-twentieth	
 tell	order,describe,declare,discover,disclose,advise,break,state,explain,detail,reveal,announce,wander,chart,report,confess,repeat,learn,leave,speak,stray,bare,relate,inform,know,give,say,notify,spill,unwrap,express,signal,voice,herald,expose,talk,instruct,air,mention,identify,chronicle,indicate,see
 pure	fine,native,true,absolute,tried,good,bright,fresh,decent,clean,plain,neat,light,sheer,real,refined,authentic,straight,perfect,filtered,natural,concentrated,purified,classic,transparent,purity,rendered,clear,processed,honest,simple,mere,pristine
 activated	tested,energetic,moved,generated,starting,enforced,drove,practiced,charged,powered,pushed,run,triggered,arising,vivid,spirited,started,reactive,beginning
@@ -13784,10 +13019,8 @@ human	mortal,animal,creature,weak,individual,humanity,personal,character,natural
 wine	belt,lavender,load,flaming,maroon,peg,coral,whisky,whiskey,cocktail,violet,pop,burgundy,sake,spirits,macon,grape,juice,plum,slug,gin,alcohol,drink,chaser,beer,glowing,sauce,brew,lush,bordeaux,vintage,mead,brandy,color,bottle,rum,shooter,ale,lilac,vodka,generic,rose,crimson,cardinal,liquor
 unrelated	irrelevant,inappropriate
 linguistic	verbal,rhetoric
-tyler	
 solutions	explanation,result,results,answers
 tin	gold,package,platinum,can,box,barrel,iron,bucket,mineral,sn,bottle,parcel,metal,jar,drum
-robinson	
 lighting	flare,lamp,lantern,spotlight,flashlight,candle,lighthouse,flash,light,beacon,chandelier
 firefighter	ranger,guardian,protector,defender
 mhz	mhz,mc,rate,khz,kc
@@ -13805,7 +13038,6 @@ bunk	bed,pallet,rack,hay,cot,sofa,couch,sack,rubbish,mattress,crib
 latch	strap,glue,tie,harness,staple,tack,clip,fix,lace,hang,link,tackle,clamp,connect,bolt,bend,screw,pin,unite,adhere,plaster,paste,stick,join,attach,nail,toggle
 journals	organs,periodicals,newspapers,editions,magazines,reviews,mags,newsletters,serials,bulletins,papers,books
 previously	once,before,earlier,already,ahead,early,now,then,formerly
-nevis	
 legendary	renowned,fabulous
 past	time,old,earlier,completed,preceding,previous,early,recent,annals,yesterday,prior,history,late,former,spent,record
 heavy	serious,substantial,dense,fat,weight,considerable,large,rough,big,violent,harsh,excessive,solid,hard,monster,awkward,complicated,huge,tough,massive
@@ -13856,7 +13088,6 @@ achievements	deed,success,performance,attainment,creation,accomplishments,succes
 migrating	touring,relocating,travelling,traveling
 jigsaw	grab,split,separate,slash,divide,saw,pull,damage,crack,break,wrench
 pitching	lifting,motion,pitch,movement,rock,move,raising,tilt,supporting
-nixon	
 call	tag,signal,contact,shout,nickname,require,reason,refer,invite,note,place,claim,term,ask,declare,invitation,order,request,calling,play,label,predict,phone,yell,proposal,name,style,dub,see,address,telephone,rename,charge,visit,scream,hail,put,appoint,announce,cry,plea,appeal
 rich	sweet,satisfying,flush,lush,warm,strong,tasty,abundant,delicious,strange,vibrant,odd,expensive,juicy,entertaining,spicy,valuable,vivid,wealthy,heavy,deep,loaded,successful,fat,creamy,full,splendid,easy,gorgeous,smart,bright,comfortable,privileged,intense,elegant,fertile
 quad	close,court,yard,deck,patio,courtyard,square,sibling,enclosure,plaza
@@ -13884,7 +13115,6 @@ yellow	cautious,scared,weak,careful,afraid,chicken
 shouts	calls,cries
 jaws	entrance,conferences,debates,box,rim,chatter,door,talks,gossip,gate,cavity,chats
 calling	ending,abortion,revocation,occupation,business,dropping,walk,speciality,line,repeal,specialization,recall,cancellation,career,job,specialty
-may	
 african	someone,individual,mortal,person,egyptian,nigerian,ethiopian,libyan,soul,moroccan,somebody
 payroll	amount,table,wage,consumption,docket,price,register,glossary,agenda,bibliography,roll,calendar,value,list,compilation,spending,budget,loss,earnings,registry,pay,mortgage,canon,schedule,index,menu,remuneration,roster,rate,catalog,insurance,debt,loan,manifest,salary,listing,enumeration,fee,tariff,catalogue,expenditure,charge,investment,risk,inventory,checklist,directory,income,sum,liability,obligation
 preface	foreword,intro,text,prelude,introduction
@@ -13899,7 +13129,6 @@ fun	pleasure,sport,entertainment,joke,joy,pleasant,celebration,delight,enjoyable
 browsing	spending,grazing,feeding,eating,browse
 shore	lakeside,reinforcement,strand,bracket,mounting,shoreline,foundation,border,formation,pedestal,arch,spur,beach,stand,stay,waterfront,support,bank,prop,brace,coast,mount,column,sand,pillar
 diversion	dancing,joke,trick,deviation,activity,nightlife,pursuit,sport,play,escape,game,picnic,recreation,bathing,pleasure,fun,interest,celebration,departure,entertainment,dance,athletics,delight,gaming,amusement,gambling
-david	
 vampires	users,predators,sharks,wolves
 rodeo	exhibition
 finances	financing,treasury,wealth,fund,pocket,assets,cash,funds,bank,roll,resources
@@ -13924,7 +13153,6 @@ periods	days,ages,years,times
 nanny	nurse,bag
 street	row,boulevard,place,route,lane,roadway,way,drive,road,paving,highway,freeway,court,arterial,alley,trail,interstate,pavement,rue,track,pike,artery,avenue,pass
 induction	investment,initiation,baptism,inaugural,installation,introduction,ceremony,installment
-freelance	
 heavenly	fantastic,frontline,cracking,sublime,fab,fine,hot,sacred,banner,better,groovy,awesome,special,great,capital,choice,top,decent,grand,immense,keen,immortal,delicious,brave,good,ethereal,prime,superb,terrific,righteous,radical,excellent,stellar,swell,quality,prize,splendid,divine,holy,celestial,famous,wonderful,gone,slick,exceptional,mean,marvelous,lovely,nifty,glorious,superior,boss,dynamite,noble,supernatural,classic,cool,beautiful,fabulous,bumper,neat,sterling
 expired	invalid,late,faded,deceased,away,dead,outside,departed,obsolete,gone,done,buried
 fractures	ruins,splits,reduces,fragments,cracks,breaks
@@ -13943,14 +13171,12 @@ lakes	basin,reservoir,ponds,lagoon,basins,pool,wells,pools,pond
 fin	two,hundred,buck,ten,five,ship,cash,dough,chips,money,dollar,one,twenty,currency,fifty
 princes	lords,stars,kings,lions
 peninsula	arm,spit,point,cape,earth,ness,ground,land
-babylon	
 hurt	pain,sting,mar,swell,bleed,discomfort,wound,upset,damage,harm,punish,trouble,smart,suffering
 correlations	interaction,relationship,similarity,correspondence,equation,parallel,equivalence
 parallel	complementary,complement,like,comparison,correspondent,akin,symmetric,twin,such,analogous,similarity,matching,equivalent,collateral,alike,correspond,comparable,analogy,corresponding,related,identical,similar
 alright	ok,fine,acceptable,satisfactory,good,okay
 w	w
 housewives	wives,women,brides,ladies
-pi	
 earnings	part,revenue,net,share,portion,gain,markup,profit,pay,proceeds,salary,return,killing,profits,dividend,cleanup,margin,percentage,yield,income,accumulation
 magnificent	luxurious,sublime,imperial,proud,tremendous,majestic,awesome,grand,remarkable,epic,massive,superb,terrific,impressive,excellent,brilliant,splendid,striking,gorgeous,wonderful,marvelous,outstanding,glorious,extraordinary,regal,noble,heroic,elegant,imposing,royal
 literally	genuinely,verbatim,positively,actually,directly,completely,accurately,simply,precisely,truly,really
@@ -13958,7 +13184,6 @@ axes	sacks,discharges,boots
 blush	bloom,colour,brightness,flush,crimson,glow,color
 opposition	resistance,struggle,reaction,rival,opponent,rebel,objection,action,protest,enemy
 callback	ring,call,recall,message,asking
-sweatshirt	
 plunge	descent,start,jump,dip,drop,drive,fall,dive,get,tumble,begin,sound,launch,sink,throw
 adequate	decent,appropriate,ok,competent,fine,suitable,adequacy,fair,worthy,minimal,acceptable,satisfactory,good,useful,okay,capable,sufficient,equal
 consistency	fitness,density,texture,coherence,compatibility,flexibility,stability,thickness,unity,harmony
@@ -13998,9 +13223,7 @@ ml	mil,cl,cc
 dignity	morality,prestige,virtue,rank,quality,distinction,pride,grace,state,status,fashion,standing,class,honor
 regulation	order,value,guideline,governance,procedure,code,control,principle,adjustment,statute,arrangement,reg,settlement,decree,instruction,supervision,management,constitution,law,restriction,ordinance,standard,rule
 somewhat	far,moderately,slightly,considerably,pretty,significantly,quite,fairly,relatively,enough,partially,rather,something
-globalisation	
 throttle	accelerator,valve
-trinidad	
 liking	love,feeling,use,interest,fancy,appetite,enthusiasm,approval,preference,desire,favor,taste,tendency,esteem,like
 holly	mate
 burr	hum,whisper,sigh,buzz,zoom
@@ -14022,14 +13245,12 @@ pocket	wealth,fund,resources,pouch,hole,assets,financing,steal,compartment,small
 retained	protected,possessed,owned,saved,preserved,received,maintained
 bleed	flow,squeeze,stick,hurt,cry,discharge,sigh,suffer,exhaust,drain,sorrow
 clarion	loud,noisy,clear,crashing,harsh,ringing
-arsenic	
 multidisciplinary	interdisciplinary
 trick	fraud,secret,bluff,illusion,accomplishment,twist,con,fetch,stunt,technique,trap,scheme,deception,skill,method,conspiracy,dodge,play,feat,gag,gift,trait,cheat,device,distortion,plot
 goals	plans,objectives,points,ideals,designs,objects,aims,purposes,things,ideas,meanings,dreams,intentions,targets,aspirations
 six	cardinal,vi
 acreage	area,lot,land,campus,estate,realty,yard,acres,plot,parcel,backyard,property,park,premises
 offenses	debts,crimes,sins,violations,errors
-pe	
 vegetation	growth,browse,stand,green,flora,foliage,bush,woods,brush,garden,collection,biology,forest,wood,scrub,accumulation,botany
 pd	metal
 cockpit	capsule,cabin,aircraft,canopy,compartment
@@ -14052,8 +13273,6 @@ herbs	flora,spices
 nick	punch,hack,notch,slot,groove,chip,cutting
 pbs	injection,mixture,extract,infusion,toner,sap
 feedback	evaluation,input,assessment,teaching,observation,brief,criticism,assistance,recommendation,direction,counsel,guidance,comment,reaction,suggestion,advice,instruction,answer,response
-catcher	
-wyatt	
 cocktail	composite,fusion,synthesis,blend,mixture,mix,blending,sour,martini,wine,compound,drink,manhattan,combination,assortment,alloy
 conservation	protection,supervision,maintenance,management,preservation,advance,care,control
 state	speak,province,say,territory,affirm,community,specify,union,explain,present,tell,articulate,federation,republic,country,put,voice,land,nation,commonwealth,describe,give,kingdom,express,sovereignty
@@ -14083,7 +13302,6 @@ fund	endowment,budget,savings,money,account,promote,assets,finance,back,supply,f
 readable	appealing,clean,engaging,straightforward,understandable,entertaining,satisfying,precise,worthwhile,sensible,fascinating,tangible,interesting,absorbing,visible,explicit,rewarding,coherent,noticeable,fair,amusing,enjoyable
 poses	presents,recommends,posture,give,votes,offers,advances,suggests,proposes,suggest,present
 porch	construction,gallery,deck,structure,piazza,balcony
-cortex	
 superior	caliber,boss,sterling,supreme,superb,preferable,banner,prime,outstanding,greatest,cavalier,ruler,ace,manager,good,principal,premium,prize,brilliant,best,important,dominant,excellent,crack,super,exceptional,remarkable,select,shining,proud,splendid,capital,quality,tops,supervisor
 replaced	relieved,substituted
 collectibles	ornaments,souvenirs,figurines,novelties
@@ -14113,7 +13331,6 @@ italy	ec,nato,piedmont,riviera,eu,rome,alps,roma,europe,italian,sicily,tivoli,tu
 whisky	whiskey,vodka,brew,beer,liquor,sake,brandy,wine,rum,manhattan,gin,spirits,cocktail,alcohol,ale,mum,scotch,rye,corn,mead,irish
 notable	distinguished,bright,prestigious,striking,renowned,notorious,serious,great,outstanding,honored,noble,superior,worthy,memorable,celebrity,evident,unusual,celebrated,prominent,signal,rare,extraordinary,remarkable,famous,noticeable,eminent,marked,noteworthy
 previous	late,anterior,earliest,former,first,precedent,initial,original,past,preceding,introductory,prior,foregoing,earlier,early
-lewis	
 facilitation	encouragement,forwarding,relief,boost,assistance,lift,advancement,mentoring,benefit,hand,assist,guidance,attendance,compensation,promotion,advice,help,cooperation,sponsorship,support,aid,backing,service
 prosecution	achievement,implementation,execution,application,commission,fulfillment,management,accomplishment,enactment,discharge,administration,performance,action,government,prosecutor,trial
 tattoos	emblem,symbol
@@ -14127,7 +13344,6 @@ necklaces	beads,strands,collars,pendants
 earlier	before,soon,former,previously,first,already,previous,past,shortly,prior,originally,ahead,early,now,formerly
 volunteer	voluntary,man,suggest
 ruler	someone,lord,monarch,sheikh,king,shah,emperor,queen,regent,person,individual,mortal,soul,stuart,master,somebody,prince,khan,sovereign
-disney	
 emergency	crisis,tension,head,difficulty,clutch,situation,necessity,accident,crunch
 expressing	stating,sounding,discussion,serious,language,saying,tone,dialogue,powerful,important,conversation,looking,expression,compelling,voice,raising,writing,giving,symbolic,announcing,describing,declaring
 trilogy	triple,trinity,trio
@@ -14141,13 +13357,11 @@ presumably	probably,clearly,likely,seemingly,surely,evidently,obviously,supposed
 initial	basic,maiden,earliest,inaugural,foremost,first,previous,original,pioneer,premier,introductory,early
 switzerland	zurich,basel,alps,europe,bern,geneva
 figure	man,someone,homo,frame,chassis,solve,fraction,resolve,build,form,symbol,body,image,decimal,digit,amount,integer,bod,price,suppose,guess,think,sum,add,shape,estimate,character,person,individual,numeric,mortal,anatomy,soul,soma,see,cost,leader,human,conclude,model,settle,somebody,rate,personality,number,discover,total,determine
-casinos	
 device	override,light,runner,charger,lure,blower,gadget,foil,converter,fender,material,keyboard,valve,pull,preventive,appliance,bluff,instrumentation,mechanism,fetch,apparatus,convenience,trap,comforter,lift,pick,accessory,method,button,conductor,sensor,trick,dodge,lighter,horn,support,instrument,surface,equipment,release,reinforcement,filter,guard,adapter,widget,safety,adaptor,bait,deception,machine,strategy,drive,stylus,restraint,router,trigger,comb,constraint,toy,feeder,prod,remote,fan,warmer,detector,key,imprint,scheme,design,magnet,flare,alarm,buffer,play,heater,indicator,corrective,reset,gear,reflector
 charters	bargains,conventions,promises,associations,partnerships,alliances,deals,agreements,contracts,treaties,settlements
 believe	regard,consider,buy,maintain,bank,suspect,feel,suppose,think,have,swear,accept,credit,swallow,trust,expect,assume,take,understand,conclude,hold,admit,rely
 kitchen	home,room
 rem	sleep
-jung	
 porcelain	cup,ceramic,plate,enamel,pottery,crystal,glass,dinnerware,tableware,ceramics,china,glassware,ware,setting,goblet
 unsuccessful	inadequate,useless,frustrated,ineffective,disappointed,empty,insufficient,failed,impossible,vain,attempted,unfortunate,ruined,success,lost,losing,out,doomed,defeated,meaningless
 will	discipline,decision,character,feeling,leave,passion,resolve,wish,power,determination,desire,intention,mind,attitude,faculty,resolution
@@ -14161,7 +13375,6 @@ pepsi	cola
 catastrophic	fatal,unfortunate,destructive,tragic
 property	wealth,lot,development,things,farm,possession,ownership,worth,estate,holding,spirituality,salvage,home,plat,goods,house,lease,parcel,trust,land,letting,realty,plot,rental,equity,tract
 marvel	genius,phenomenon,sensation,beauty,miracle,wonder,react,stare
-sos	
 farmers	grower,producer,growers
 proficient	educated,accomplished,talented,great,ace,good,trained,capable,complete,crack,practiced,competent,apt,master,efficient,skilled,gifted,qualified,experienced,expert,veteran
 mix	absorb,weave,combination,combine,assortment,fusion,merge,melt,flux,incorporate,cocktail,mixture,blending,gauge,compound,fuse,alloy,composite,synthesis,blend,associate,stir
@@ -14189,19 +13402,16 @@ shoot	charge,kill,execute,run,discharge,strike,explode,chase,launch,project,pass
 moral	honourable,ethical,right,true,clean,proper,upright,morality,noble,worthy,good,respected,nice,meaning,significance,just,decent,righteous,honest,straight,honorable
 barker	dog
 opposing	contrary,inconsistent,opposite,conflicting,hostile,incompatible
-esp	
 subjective	private,unique,individual,personal,abstract,singular,particular,biased,personalized,distinctive,intuitive,separate
 oxidation	burning,rust,erosion,heat,blaze,combustion,deterioration,reaction,decay,decomposition
 spend	holiday,invest,serve,kill,do,waste,consume,winter,concentrate,drop,go,pass,allocate,weekend,employ,use,pay,contribute,donate,vacation,settle,summer,give,soldier
 psa	protein
-diablo	
 fender	padding,bumper,car,wing,pad,cushion,barrier,buffer,automobile,machine,shield
 mysteries	question,problem,puzzles,matters,challenges,secrets,secrecy,riddle,thriller,problems
 boiled	baked,burnt,grilled,heated,saturated,burned,roasted,fried,cooked
 acronym	form
 diaries	journals
 material	physical,timber,emission,data,information,object,mineral,fibre,dust,considerable,waste,textile,discharge,litter,serious,text,stone,ingredient,chemical,evidence,builder,cloth,filling,possibility,particulate,element,color,fiber,aggregate,earth,significant,conductor,supply,ammunition,work,potential,bedding,adhesive,goods,foam,molecule,making,paper,meaningful,fill,substantial,component,precursor,machinery,toner,actual,atom,contamination,staple,equipment,substance,colour,ground,particle,stuff,rock,packing
-colonel	
 temporal	physical,sensual,terrestrial,daily,bodily,material,animal,temporary
 phantom	legendary,spirit,invented,fantastic,imagined,theoretical,fictional,ideal,imaginary,unreal,pretend
 benchmark	metric,par,measure,instance,grade,gauge,example,criterion,standard,rule
@@ -14245,13 +13455,11 @@ class	degree,order,club,position,layer,seminar,category,estate,tier,course,leagu
 perhaps	sure,probably,surely,certainly,maybe,possibly
 salvage	rescue,retrieve,redeem,restore,regain,recover,deliver,save
 rebuilding	reclamation,renovation,recovery,renewal,fixing,reconstruction,revival,rehabilitation,repair
-serif	
 slides	slips,inches,snakes,steals
 rot	punk,bunk,nonsense,beans,deterioration,fiddle,hang,jazz,fudge,insanity,blah,madness,decomposition,bull,warp,stain,trash,nuts,garbage,rubbish,decay
 well	strong,correctly,reservoir,right,easily,hole,sufficiently,alright,properly,effectively,appropriately,good,successfully,ok,fine,far,freely,accurately,carefully,pit,completely,closely,adequately,intelligent,smoothly,thoroughly,pool,together,source,mine,quite,okay,basin,fully,efficiently,strongly,nicely
 subchapter	post,wing,arm,division,chapter
 metal	hf,os,np,bk,copper,cobalt,na,hardware,rb,li,aluminium,potassium,zinc,al,ga,re,nb,material,mercury,u,la,uranium,magnesium,th,stuff,ti,gd,po,aluminum,cf,in,sb,mineral,v,mg,chromium,cs,ni,mo,tm,ra,ho,sm,sr,y,tb,potential,ir,matter,pa,mn,tl,pd,ore,pm,nickel,dy,er,sodium,e,nd,possibility,ce,cu,spirit,tc,k,soul,be,alloy,tin,tungsten,lead,pr,w,lithium,titanium,timber,lu,cm,am,es,fm,fe,co,eu,rh,element,essence,hg,fr,iron,making,bi,ca,cr,ta,ba,cd,calcium,ru,sc,substance,sn,pb
-guitar	
 classification	analysis,generation,coordination,category,assortment,set,section,tier,indexing,arrangement,league,designation,group,allocation,class,sort,regulation,taxonomy,genus,distribution,species,bracket,variety,kind,division,grouping,type,family,grade
 tampa	florida
 instructions	charges,words,manual,directives,orders,program,course,project,procedure,prescription,requirements,commands,policy,directions,commandments,method,technique
@@ -14264,10 +13472,8 @@ memberships	outfits,organizations,groups,parties,camps,teams,institutions,circle
 warfare	dispute,struggle,action,fight,war,friction,conflict,aggression,division,dissent,combat,competition,battle,engagement,fighting,jihad,variance,bw,clash
 even	truly,surely,indeed,nay,positively,undoubtedly,really,definitely,certainly,yet,much
 approval	backup,ratification,sanction,favor,vote,approving,license,confirmation,adoption,acceptance,nod,mandate,ok,recommendation,permission,liking,endorsement,championship,agreement,satisfaction,blessing,support,okay,backing,reward,consent,reinforcement
-mines	
 styling	motto,treatment,administration,saying,naming,terminology,tagging,labeling,manipulation,remark,care,branding,approach,slogan,wording,expression,specifying,supervision,labelling,conduct,calling
 furthermore	besides,likewise,too,also,more,either,then,additionally,yet,further,moreover,again
-luke	
 honestly	truly,positively,frankly,really,absolutely,certainly,fairly,sincerely,indeed,genuinely,actually
 whichever	anything,that,whatever
 minor	adolescent,slight,boy,child,baby,infant,subordinate,girl,lower,negligible,lesser,youth,petty,teenager,small,less,secondary,juvenile,junior,smaller,trivial
@@ -14327,7 +13533,6 @@ noticed	witnessed,distinguished,eyed,saw,spotted,viewed,observed,identified,perc
 southwest	sw
 excluded	illicit,neglected,suppressed,refused,unwanted,prohibited,unpleasant,unsolicited,stopped,forgotten,isolated,objectionable,blocked,restricted,unacceptable,unauthorized,prevented,rejected,revoked
 y	y,letter
-aaa	
 destiny	chance,circumstance,doom,inevitable,occurrence,objective,luck,karma,intention,future,fate,fortune,happening,prospect
 dispersed	scattered,inadequate,assigned,disappeared,distributed,spread,shared,melted,weak,dissolved,thin,divided,scarce,separated,appropriated,faded
 husband	mate,mister,man,companion,benedict,spouse,groom,partner
@@ -14341,7 +13546,6 @@ drawers	boxes,cabinets,pants
 characteristic	fingerprint,sign,unique,symbol,marker,note,symptom,point,specific,property,hallmark,tone,attribute,typical,criterion,virtue,tendency,distinctive,essence,character,mark,stamp,indication,feature,affection,flavor,nature,singular,attribution,component,aspect,style,trait,quality,diagnostic,personality,peculiar,touch
 rectangular	super,jumbo,large,oversized,angular,considerable,extensive,substantial
 ignorance	innocence,blindness
-circuits	
 horsepower	might,intensity,capacity,force,weight,effort,capability,watt,hp,energy,heat,potential,muscle,electricity,violence,power,w,service,strength
 equilibrium	balance,stability,serenity,situation,symmetry
 addressing	apology,hacking,treating,negotiating,managing,gratitude,swinging,playing,response,taking,handling,reaction,fielding,confession,appreciation
@@ -14357,7 +13561,6 @@ devices	genius,impulse,bent,flair,furnishings,bias,apparatus,affinity,dispositio
 estimate	evaluation,valuation,value,measure,rating,consider,appraisal,make,assessment,estimation,set,guess,calculate,classify,analyze,evaluate,conclusion,projection,survey,rank,approximate,examine,expect,gauge,put,place,figure,count,give,assess,opinion,rate,believe,compute,judge,measurement,predict,decide,determine
 forte	gift,area,discipline,asset,thing,business,department,strength,talent,field,plus,specialty,tendency,domain,speciality
 passport	warrant,permission,permit,secret,gateway,license,pass,key,authorization,safeguard,visa,ticket
-pistols	
 theater	movie,cinema,theatre,site,pit,circle,playhouse,house,hall,opera,room,building,auditorium,drama,scene,stage,arena,orchestra
 assume	bear,consider,embrace,adopt,suspect,undertake,suppose,guess,think,begin,estimate,accept,expect,understand,affect,conclude,acquire,anticipate,shoulder
 gi	wash,clean,wipe,rinse,brush,gilbert,scrub
@@ -14383,14 +13586,12 @@ undo	mar,undermine,wreck,spread,scare,ruin,open,waste,reverse,destroy,offset,unl
 counselling	wind,lead,counseling,steer,hint,counsel,content,compassion,guidance,sympathy,message,substance,tip,direction
 truths	credibility,principle,faith,reliability,integrity,accuracy,correctness,revelation,authenticity,fact,legitimacy,certainty,realism
 let	allow,leave,permit
-das	
 canyon	canon,gap,saddle,trench,gorge,pass,col,valley
 hardware	apparatus,tools,stuff,tackle,equipment,facilities,housewares,plumbing,gear,machinery,kit
 drafting	recruiting,craft,trade,volunteering
 try	push,struggle,seek,test,tax,chance,fight,essay,hear,endeavor,act,strain,bother,endeavour,work,investigate,stretch,adventure,attempt,gamble,hazard,strive,attack,prove,assay,risk,move,decide
 insights	understanding,grasp,judgment,sensitivity,intellect,vision,sense,intelligence,perception,comprehension,power,reason,penetration,wisdom,intuition,observation,wit,appreciation
 injury	offence,bump,scar,sting,break,loss,trauma,twist,fracture,swelling,harm,pinch,insult,strain,cut,disability,shock,abuse,bleeding,damage,wound,wrench,bite,hurt,sore,pull,burn,suffering
-cam	
 calendars	schedules,organizations,agendas,cards,programs
 cyprus	mediterranean
 obese	ripe,gross,fat,plump,thick,heavy,husky,round,full,overweight,chubby,stout
@@ -14409,7 +13610,6 @@ pathways	routes,roads,trails,paths,tracks
 credits	wealth,balance,stock,accept,flick,pic,consider,film,listing,picture,loan,trust,bond,acknowledgement,trusts,movie,mortgage,list
 empty	stripped,escape,clean,glazed,discharge,consume,drain,void,gut,idle,open,stark,drained,blank,dry,hollow,drink,exhaust,bare,leak,vacant,flat,clear,white,dump,meaningless
 rebates	deductions,reductions,discounts
-bbs	
 longitude	span,area,duration,diameter,piece,site,portion,range,district,residence,field,position,hole,situation,magnitude,point,space,corner,section,community,town,room,limit,apartment,region,zone,home,segment,stretch,radius,house,country,dimension,mileage,spot,term,venue,part,breadth,width,height,quantity,neighborhood,village,seat,city,period
 employing	recruiting,retaining,assuming,hiring,placing,engaging,paying
 latitude	line,slack,space
@@ -14458,15 +13658,12 @@ caffeine	tea,java,espresso
 fools	idiot,monkeys,cheat,dummies,jerk,clown,nuts,pretend,idiots,losers
 researching	studying,investigate,explore,probing,investigating,analyze,consult,probe,examining,exploring
 greece	nato,arcadia,crete,ithaca,doris,argos,eu,olympus,europe,lesbos,delphi,athens,greek,rhodes,ec
-titus	
 ireland	galway,tara,eu,dublin,limerick,europe,cork,ec
 stairs	ladder
 food	chow,beverage,snack,cooking,meat,nutrient,tucker,water,supplies,bread,nutrition,diet,fare,medium,edible,feed,chuck,eats,drink,meal,table,dish,plate,cuisine,provisions,substance
 operate	roll,engage,serve,transport,keep,run,do,promote,function,produce,set,explore,administer,manipulate,go,act,complete,use,drive,work,double,achieve,play,take,conduct,handle,service,move
-burt	
 razor	blade,knife
 wines	juices,spirits,drinks,sauces,cocktails,bottles,belts,loads,beers
-surnames	
 chateau	home,palace,place,estate,housing,roof,manor,castle,villa,house,hall,mansion,dwelling
 hot	warming,red,spicy,heated,warm,boiling,thermal,trendy,sharp,intense,baking,burning,popular,fresh,tropical,fierce,fiery,cool,temperature,het,white
 tournament	battle,race,fight,series,athletics,bout,meeting,contest,competition,open,test,match,game,sport,event,sweepstakes,championship,meet
@@ -14494,7 +13691,6 @@ arkansas	america,us,ar,fayetteville,white,dixie,usa,south
 halo	sense,climate,aroma,flavor,karma,mood,glory,feeling,air,aura,light,atmosphere,smell,temper,odor,feel
 luxury	accessory,option,extra,indulgence,comfort,enjoyment,leisure
 letting	allowance,tolerance,property,sympathetic,warrant,permit,rental,leave,ok,enabling,recognition,permitting,okay,agreement,compassionate,holding,admission,allowing,licensing,clearance,endorsement,sanction,acceptance,concession,permission,approval,licence,consent,authorization,privilege,compliant,lease,granting,tolerant,benign,license,support
-seismic	
 screens	walls,protections,weapons,covers,defenses,guards,securities,safeguards,shields,wards
 consideration	evidence,discussion,exploration,idea,review,weighing,respect,scrutiny,examination,factor,awareness,study,reflection,attention,thought,proposal,concern,development,application,thinking,debate,judgment,plan,account,issue,difficulty,problem
 subdivisions	departments,offices,agencies,desks,branches,divisions,services
@@ -14519,7 +13715,6 @@ playhouse	arena,hall,house,room,drama,barn,auditorium,film,cinema,theatre,scene,
 handicap	minus,impairment,negative,disability,advantage,debit,disadvantage,liability,benefit,obstacle,restrict
 newsletters	journal,magazines,mags,organs,serials,books,papers,periodicals,editions,magazine,newspapers,journals,reviews,bulletin,bulletins
 gasket	seal
-athena	
 news	info,bulletin,broadcast,story,rumor,report,coverage,message,headlines,information,announcement,intelligence,account,reporting,word,item
 vhf	symptom
 scorecard	list,catalogue,card,book,almanac
@@ -14541,7 +13736,6 @@ participant	partner,shareholder,actor,colleague,groom,member,bride,player,party,
 turner	acrobat
 fragments	wreck,earth,pieces,residue,sediment,rubbish,waste,bits,powder,junk,portions,soil,dirt,litter,fractions,remains,scraps,debris,sand,trash
 carbonate	salt
-alumni	
 participates	shares,receives,experiences,knows
 expire	stop,halt,stall,pass,end,finish,terminate,determine,go,depart,quit,close,cease,conclude,die
 signup	subscribe,author,autograph,endorse,ink,initial,sign
@@ -14550,7 +13744,6 @@ seems	show,feels,imply,sounds,look,acts,makes,suggest,sound,looks,appears
 amateurs	enthusiasts,fans
 collateral	warranty,effects,property,guarantee,possession,bond,treasures,pledge,gear,stuff,assurance,security,things,contract,holdings,deposit,goods
 bonds	traps,irons,property,chains,detention,bands,constraints,ties,bracelets,binds,holdings,custody,jail,share,collars,restrictions
-treasurer	
 toe	floor,bottom,base,belly,digit,feet,sole,toes,seat,foot,ground
 zine	journal,yearbook,serial,periodical,gazette,rag,magazine,organ,newspaper,mag,newsletter,paper,review,bulletin,book
 oblique	diagonal,distorted,crooked,tipping,vague,pitched,listing,crazy,bias,inclined
@@ -14564,17 +13757,14 @@ torrent	waterfall,niagara,cascade,tide,river,flood,blizzard,rain,avalanche,rainf
 permanently	ever,always,long,forever,ay
 regulate	control,coordinate,oversee,keep,conduct,administer,supervise,correct,suppress,contain,handle,classify,inhibit,improve,measure,govern,monitor,determine,hold,check,balance,stop,curb,adjust,rule
 conduit	piping,tube,line,passage,spill,tubing,pipe,pipeline,duct,channel,drain,leader
-tyrosine	
 poems	lyrics,verses,songs,rhymes
 bothered	distressed,troubled,upset,mad,frustrated,annoyed,angry,disturbed
 midnight	night,late,hour,overnight,nightly,dark
 widely	broadly,extensively,globally,commonly,generally
 equities	justice,tolerance,fairness
 cartoon	humour,wit,image,publication,animation,portrait,illustration,sketch,strip,outline,parody,representation,satire,silhouette,drawing,humor
-ecuador	
 entrepreneurship	businessman,vendor,buyer,retailer,dealer,seller,purchaser,trader,merchant
 unofficial	informal,personal,summary,loose,unauthorized,irregular
-sheraton	
 charms	delight,magic,glamour,please,appeal,grace,beauty,attract,wow,symbols
 subdivision	segmentation,agency,partitioning,branch,partition,division,department,service,bureau,office,desk
 radiation	energy
@@ -14586,14 +13776,12 @@ influences	impressions,climate,pulls,impacts,ins,authorities,weights,element,cre
 blindness	ignorance,absorption,defect,nirvana
 damaged	half,injured,deficient,flawed,broken,incomplete,impaired
 battery	collection,artillery,bunch,parcel,batch,knot,mixture,package,set,cluster,lot,clutch,variety,grouping,group,bank,assortment,band,accumulation,suite,array,block,series
-pneumonia	
 finding	designation,solving,find,validation,location,localization,locating,holding,verdict,identification,decision,proof,judgement,sentence,doom,conclusion,discovery,recommendation,judgment,resolution,ruling,data,determination
 terrorist	sword,hacker,revolutionary,menace,threat,sniper,radical,violence,terror,rebel,pressure,fear,bomber
 spill	bare,flow,expose,announce,disclose,overflow,leak,empty,share,discharge,pour,reveal,tell,move,uncover,shed,discover,splash,spray,stream,squirt
 maths	science,figures,calculations,math,numbers,mathematics,measurements
 texts	readers,dictionaries,textbooks,manuals
 tibet	everest,asia
-chilean	
 recommends	propose,commits,submits,back,gives,trusts,assigns,delivers,passes,advocate,endorse,praise,favor,leaves,confirm,delegates,justify,prescribe,urge,transfers,hands,suggest,grants,vests
 ease	relax,facilitate,simplicity,luxury,lift,promote,mitigate,speed,relaxation,slide,serenity,grease,simplify,edge,efficiency,relieve,improve,travel,familiarity,content,calm,accelerate,moderate,further,satisfaction,flexibility,comfort,slip,smooth,go
 tandem	organization,surrey,carriage,side,buggy,unit,coupe,placement,squad,company,cab,gig,lineup,diligence,rig,coach,victoria,party,club,trap,tonga,stage
@@ -14604,7 +13792,6 @@ owing	due,unpaid,payable,owed,outstanding
 zoo	facility,disturbance,clutter,coil,hurricane,fun,bother,stew,installation,hurry,stir,storm,noise,row
 teamwork	partnership,synergy,coordination,harmony,cooperation,collaboration,unity
 gill	gal,girl,girlfriend,woman,flame,lover,mistress,lady
-goa	
 restricting	restrictive,limiting
 tutors	mentors,institute,lectures,guides,personnel,department,staff,teaches,schools,coaches,university,lessons,trains
 tops	distinguished,important,excellent,covers,unique,eminent,greatest,pinnacle,exceptional,jackets,height,outstanding,breathtaking,super,deadline,unprecedented,special,fantastic,superb,perfect,impressive,selection,leading,great,ceiling,selected,singular,caps,hoods,stellar,awesome,unbelievable,incredible,eclectic,paramount,exclusive,finest,restraint,first,prize,remarkable,dominant,peak,marvelous,selective,spectacular,check,superior,curb,choice,outrageous,cap,apex,famous,preferred,crack,terrific,magnificent,restriction,maximum,rare,privileged
@@ -14612,7 +13799,6 @@ journal	publication,periodical,rag,organ,magazine,newspaper,mag,review,daily,ser
 conference	panel,assembly,meeting,forum,congregation,symposium,discussion,audience,gathering,association,organization,seminar,league,talk,consultation,interview
 tactic	technique,procedure,trick,program,method,strategy,scheme,plan,means,system,way,tactics,project
 un	tc,sc
-clark	
 tubs	pipes,drums
 studied	deliberate,considered,informed,designed,calculated,knowing,advised,prepared,careful,planned,measured,thoughtful,intended,weighed
 movers	carriers,vehicles
@@ -14622,7 +13808,6 @@ weir	gate,ditch,canal,exit,port,fence,block,bank,barrier,dam,channel,door,bar,lo
 modeling	simulation,design,shaping,conforming,establishing,tuning,modifying,remodeling,transforming,putting,fitting,customizing,correcting,model,adjusting,altering,editing,representation,painting,preparing,conditioning,matching
 complex	colonial,involved,complicated,composite,difficult,structure,hard,baroque,compound,disturbing,obscure,varied,system,network,elaborate,sophisticated,complexity
 finishes	completes,does,achieves
-f	
 cleaner	soap,formulation,shampoo
 elastic	plastic,lively,flexible,expandable,live,stretch,adjustable
 interconnection	link,joining,tie,attachment,joint,junction,intersection,linkage,join,nexus,connection,coupling
@@ -14651,7 +13836,6 @@ parade	ceremony,show,demonstration,demonstrate,flash,ritual
 whitewater	waterfall,foam,bubble,shoot,cascade,whitewater,head
 clam	one,dollar,buck,bone
 procedures	systems,processes,proceedings,methods,operations,techniques,courses,manners,ways
-otis	
 clarified	fresh,purified,neat,fine,pure,plain,filtered,processed,concentrated,absolute,rendered,refined,tried,clean,straight
 blogs	stories,histories,reports,witnesses,annals,journals,commentaries,versions,memoirs,tales,records,chronicles,testimonials,logs,diaries
 chancellor	referee,expert,agent,head,judge,principal,inspector,representative,authority,minister,secretary,critic,manager,commissioner,administrator,leader,justice,court,officer,executive,director
@@ -14733,7 +13917,6 @@ karate	wrestling
 minister	executive,official,delegate,secretary,representative,bishop,agent,aide,ambassador,pastor,reverend,administrator,deputy
 distributors	wholesalers,retailers,vendors,buyers,sellers,marketers,entrepreneurs,providers,suppliers
 dates	appointments,meetings,engagements,schedules
-renovations	
 soluble	feasible
 diner	booth,cafe,grill,saloon,carver,restaurant,bistro,cafeteria,eater,feeder
 broadcasters	columnists,reporters,editors,anchors,journalists
@@ -14769,13 +13952,11 @@ security	surveillance,protection,safety,care,insurance,confidence,shield,safegua
 blows	battle,combat,fighting,competition,war,struggle,pants,clash
 souls	genius,thought,vitality,man,woman,ego,heart,spirits,courage,body,mind,spirit,conscience,life,character,feeling,person,stuff,intelligence,creature,individual,ghost,intellect,personality
 flower	blossom,veronica,poppy,stock,cosmos,sunflower,bud,pink,herb,daisy,orchid,bloom,mature,composite,perennial,vine,thrive
-mri	
 ordering	disposition,formation,analysis,device,ruling,blueprint,project,administrative,grade,coordination,transaction,array,design,style,designation,ladder,guiding,plan,string,layout,calibration,composition,method,arrangement,rule,program,modification,order,performing,strategy,form,proposal,theory,disposal,shape,alteration,transfer,running,distribution,regulation,ranking,series,procedure,system,dominant,improvement,progression,setup,genome,graduation,hierarchy,line,placement,structure,content,rank,scale,pattern,sequence,allocation,shopping,level
 statistics	data,stats,correlation
 bolts	springs,jumps,starts
 cox	enzyme
 xerox	copy
-roth	
 termed	known,designated,celebrated,titled,specified,dubbed,labeled,labelled,named
 bitmap	icon,image,picture
 toxic	deadly,poison,harmful,lethal
@@ -14789,7 +13970,6 @@ location	somewhere,locus,region,object,point,northeast,district,east,jungle,pass
 dragging	slowing,slow
 means	spells,suggests,wings,step,salvation,escape,process,tooth,equipment,implies,way,indicates,aid,medium,implementation,measure,explains,represents,mode,imports,tactic,power,factor,signifies,intends,expresses,system,technique,denotes,road,mechanism,agency,voice,instrument,route,tool,vehicle,symbols,channel
 unspecified	given,specific,unnamed,one,undefined,certain,anonymous,unidentified,some
-hughes	
 inland	interior,midland
 immense	heroic,big,grand,bumper,enormous,giant,astronomical,cosmic,gigantic,vast,planetary,extensive,monster,mega,super,oversized,galactic,huge,mammoth,considerable,mighty,great,large,tremendous,substantial,titanic,infinite,oceanic,endless,massive
 wash	lap,washing,soak,splash,wipe,shower,serve,rinse,shampoo,scrub,hose,wet,cleaning,float,bubble,lip,process
@@ -14805,12 +13985,10 @@ combat	beat,oppose,contest,battle,duel,action,withstand,encounter,warfare,cope,r
 riches	holdings,worth,treasure,prosperity,fortune,assets,money,funds,capital,abundance,gold,things,possessions,wealth,means
 organ	rag,gazette,review,lens,bulletin,book,forum,ministry,yearbook,contractor,magazine,journal,wing,gland,receptor,tongue,member,foot,newsletter,zine,agency,structure,mag,paper,instrument,serial,periodical,newspaper,unit
 pills	tablets,doses,capsules,caps,drugs,medications
-lund	
 obedience	submission,compliance,discipline,surrender,conformity
 swallowing	eating,drinking,consuming,licking,downing
 boasts	blows,possess,displays,own,exhibit,exhibits,claim
 beware	notice,ware,note,mind,see,watch
-acne	
 weaving	volatile,spiral,curling,tricky,slippery,turned,unpredictable,sensitive,winding,bending,curved,weak,ambiguous,intermittent,twisted,risky,rocky,turning,uncertain
 r	letter
 symbolic	typical,representative,significant,token
@@ -14892,7 +14070,6 @@ sprint	speed,dash,hurry,leap,break,dart,skip,running,trip,run,zip,race,rush
 infections	flu,pollution,bug,disease,virus,attack,epidemic
 limits	work,domain,region,vicinity,dimension,department,zone,horizon,blocks,control,discretion,suburb,district,territory,commission,length,scope,check,job,bounds,area,supervision,arbitration,rule,terrain,constraint,field,limit,logic,matter,restraint,barrier,condition,frontier,surroundings,authority,perimeter,power,regulation,border,space,range,administration,reasoning,sense,spectrum,curb,line,edge,caps,province,sovereignty,command,environment,influence
 arctic	bitter,cool,freezing,polar,cooled,chill,cold
-castro	
 bloom	grow,autumn,flowering,blossom,revival,flower,thrive,pinnacle,prime,flush,develop
 cheats	doctors,fakes,colors,stretches,pads
 settlement	covenant,promise,resolution,colony,convention,payment,outpost,treaty,arrangement,agreement,body,deal,understanding,compact,compensation,establishment,contract,colonial,bargain,pact
@@ -14949,7 +14126,6 @@ routing	occupation,succeeding,smoking,sweeping,beating,scoring,overwhelming,over
 worth	merit,price,rate,significance,benefit,account,quality,cost,aid,value,valuation,credit,worthy,importance
 prognosis	prophecy,forecasting,diagnosis,prospect,forecast,projection,prediction,predicting
 taxes	expense,tariff,price,rate,charge,fine,impose,assessments,contribution,cost,assess,exhaust,duties,duty,levy,tariffs
-chars	
 bishop	director,clerical,archbishop,pope,preacher,dean,shepherd,priest,cardinal,pastor,administrator
 plaster	lotion,mixture,cream,adhesive,lime,glue,dressing,paste,mortar,cement
 magnet	core,stimulus,center,draw,incentive,device,attraction,pole
@@ -14966,14 +14142,12 @@ tc	council
 protectors	guards,champions,defender,guardians,defenders,protections,partisan,patron,savior
 sooner	ahead,shortly,promptly,rather,since,immediately,now,presently,back,previously
 nightly	night,cyclic,daily,monthly,nightly,midnight,annual,hourly,yearly,evening,periodical,weekly
-sauces	
 pricing	opinion,analyzing,assessment,evaluating,learning,settling,surveying,assessing,determining,judging,setting,rating,survey,estimating,testing,evaluation,valuation,discovering,deciding
 packet	bag,envelope,package,collection,carton,sack,accumulation,bundle,container,box,parcel,folder,wrapper,pouch,pack
 treasures	preserve,reserve,highlights,valuable,prize,conserve,jewel,gold,riches,worship,cache,boasts,features,gem,money,wealth,honors,attractions,cash,jewels,appreciate
 johnny	rebel
 explored	exposed,researched,disclosed,inspected,detected,studied,scanned,invented,identified,examined,investigated,viewed
 attacking	charging,rushing,destructive,striking,restless,threatening
-islam	
 inaugural	previous,original,foremost,earliest,initiative,maiden,first,pioneer,opening,early,premier,initial
 valves	gates,faucets,taps
 players	performers,musicians,artists,list
@@ -14988,7 +14162,6 @@ sawyer	logger,jack
 consensus	harmony,unity,consent,accord,agreement
 perspective	forefront,opinion,vanguard,view,position,outlook,viewpoint,prospect,mind,paradigm,attitude,angle,shoes,standpoint,aspect,context,orientation,light
 positions	opinion,view,employs,reputation,point,duties,location,duty,stand,stick,offices,appointments,jobs,professions,job,locate,viewpoint,area,attitude,state,slot,arrangement,place,put,spot,situations,office,condition,role,spots,situation,connections,standing,functions,arrange,post,posts,works,occupations,places,seat,status,rank,postings,environment,capacities,stance
-omb	
 completing	decisive,ultimate,specific,doing,finishing,achieving,additive,executing,integral,actual,definite,polishing,reciprocal,precise,exhaustive,fulfilling,reliable
 calculator	machine,counter
 abbreviations	reviews,outlines,abstracts,surveys,sketches,summaries
@@ -15008,7 +14181,6 @@ mana	karma,qi,energy,aura,chi,spirit,life,soul,light,ki
 dare	threaten,challenge,resist,brave,confront,act,oppose,insult
 tenders	gives,submits,offers,volunteers,extends
 throat	neck,tongue
-realtor	
 dis	mock,offence,tease,abuse,dart,offense,hound,insult,dig,name,cut,dismiss,criticism,slight,badger,interrupt,attack,slap,barb,knock,personality
 bridges	traverse,dust,continents,unite,lands,platform,islands,span,dirt,zones,grounds,earth,link,soil
 prisons	pens,coolers,cages
@@ -15016,7 +14188,6 @@ battles	fights,action,strive,clash,argue,crusade,dispute,efforts,encounter,comba
 shared	public,multiple,common,united,mutual,reciprocal,communal,collaborative,joint,cooperative,collective,combined
 quinta	continent,region,residence,ground,district,territory,shore,ranch,area,nation,plot,country,countryside,terrain,field,earth,parcel,soil,acreage,beach,home,farm,homeland,tract,plantation,province,estate
 noun	nominal,substantive
-dew	
 annual	almanac,quarterly,yearbook,daily,monthly,yearly,weekly,reference
 hairy	fluffy,rough,silky,fuzzy,furry,haired
 cracks	pops,splits
@@ -15033,7 +14204,6 @@ became	came,got,went,turned,come,grew,ran
 spyware	software,package
 hope	strive,achievement,promise,confidence,allow,wish,faith,design,calculate,dream,look,prospect,goal,expect,plan,assume,anticipation,intend,want,desire,try,believe,consider,ambition,aspire,debate,propose,struggle,expectation,anticipate,mean,optimism,attempt,aim,purpose,hold,endeavor,concern,belief
 anyone	somebody,public,anybody,you,one,someone,all,everybody,everyone
-essex	
 foreign	multinational,offshore,introduced,multicultural,alien,international,imported,overseas,unfamiliar,different,exotic,outside,external
 running	live,going,alive,active,working,dash,travel,constant,operating,functioning,sprint,on,living,operational,functional,run,operative
 angels	colts,cubs,babes,sheep,virgins,saints
@@ -15048,7 +14218,6 @@ advertisement	report,brochure,advert,bulletin,ad,propaganda,promotion,display,no
 figures	opinion,picture,count,stats,numbers,mathematics,arithmetic,data,testimony,estimation,algebra,math,calculation,evidence,ballot,goods,calculus,vote,survey,input,info,geometry,knowledge,computation,statistics,voting
 mileage	usefulness,distance,utility,benefit,avail,account,service,value,help,use,advantage,assistance
 yeast	cause,encouragement,momentum,impulse,stimulus,motivation,fuel,reason,incentive,boost,spur,catalyst
-seneca	
 waiting	doubt,ready,accessible,qualified,consideration,uncertainty,handy,apt,delay,ripe,pause
 gun	clip,weapon,arm,magazine,action,firearm,stock,piece,rifle,trigger,extractor,mortar,barrel,pistol,cannon,shotgun,hardware
 cns	system,brain
@@ -15063,7 +14232,6 @@ monopoly	ownership,holding,corner,market,patent,trust
 weighed	measured,informed,knowing,conscious,considered,advised,intended,studied,calculated,deliberate,treated,careful,planned,thoughtful,prudent,cautious
 marshall	organize,marshal,rally,arrange,order,activate
 brides	men,mates,partners,husbands,wives,ladies,spouses
-pid	
 efficiency	ratio,ability,competence,productivity,readiness,energy,capability,effectiveness,expertise,performance,talent,skill,efficacy
 empowering	privilege,commissioning,certification,authorizing,charter,warrant,consent,choice,grant,concession,designation,visa,qualifying,selection,approval,nomination,allowing,investing,allowance,licensing,patent,permission,permitting,election,enabling,passport,license
 throughout	about,over,on,across,through,around
@@ -15074,12 +14242,10 @@ prosecutors	lawyers,counselors,lawmakers,legislators,advocates,attorneys,solicit
 activation	drive,animation,start,activity,spark,charge,fuel,run,power,trigger,push,generate,move
 realize	produce,reach,recognize,receive,get,find,do,accomplish,grasp,see,discover,know,achieve,think,understand,hear,ascertain,learn,recognise,attain,complete,realise
 tooth	liking,bone,favor,canine,taste,anterior,pulp,love,teeth,preference,yen,shine,os,root,tendency,enthusiasm,like,chopper,bias,grinder,interest,desire,crown,posterior,fancy,prejudice,leaning,appetite,use,bent
-html	
 viewer	spy,witness,observer,spectator,browser
 chopped	divide,slash,cut,hack,sliced,cube,ground
 sufficiently	enough,moderately,properly,fairly,adequately
 wood	pine,wicker,linden,log,hardwood,cypress,bamboo,ash,spruce,maple,chestnut,elm,spindle,hickory,deal,lumber,mahogany,olive,teak,gum,hazel,beam,knot,oak,fir,beech,walnut,redwood,timber,cherry,woodland,birch,cedar,ebony
-orgies	
 staying	continuous,everlasting,persistent,permanent,tenacious,frequent,strong,perpetual,healthy,recurrent,ongoing,constant,stout,durable,endless,enduring,established,hardy,eternal,sound,tough,fit,repeated,hard,familiar,sturdy,suspension,vigorous,lasting,stable,immortal,steady,delay
 stripper	performer
 skeptical	paranoid,curious,careful,unsure,suspicious,questioning,cautious
@@ -15095,7 +14261,6 @@ splash	paddle,squirt,dash,handful,suspicion,spark,shadow,trace,nip,wet,touch,bit
 arbitration	judgement,compromise,mediation,judgment
 curricular	graduate,academic,educational,scholarly,postgraduate,scholastic,collegiate,intellectual
 lacked	insisted,commanded,pressed,required,wanted,demanded,involved,want,challenged,require,asked,need,claimed,needed,bore
-cfo	
 accountancy	occupation,accounting,job,line,business
 basically	mainly,mostly,partially,commonly,usually,typically,largely,partly,practically,normally,essentially,generally,primarily,most,predominantly,principally,substantially
 casino	pavilion,kiosk
@@ -15109,9 +14274,7 @@ repeats	echoes,summarizes
 christ	savior,jesus
 serenity	peace,quiet,hush,still,patience,calm,silence
 structural	constitutional,skeletal,basic,architectural
-dd	
 boundaries	limits,barriers,ends,caps,border,limitations,bounds,lines,perimeter,frontier,barrier,horizon,ceilings,line,edge
-mauritius	
 budgets	savings,pools,funds,collections,deposits,accounts
 awaited	likely,expected,due,predicted,scheduled,coming,anticipated,upcoming,eventual,proposed,approaching
 sneak	steal,snake,hide,mouse,slip,walk,slide,creep,crawl
@@ -15172,17 +14335,13 @@ boys	youths,teenagers,youth,kids,child,adolescents,toddlers,lad,fellow,guy
 posted	experienced,wise,based,accomplished,aired,learned,published,declared,announced,smart,prevalent,placed,widespread,displayed,general,informed,proclaimed,conscious,scientific,unclassified,advertised,broadcast,brilliant,reported,educated,sophisticated,studied,scholarly,current,disclosed,insightful,sensible,shared,knowledgeable,intelligent
 continued	high,stable,repeated,persistent,lasting,great,repetitive,frequent,perpetual,sustained,regular,running,extended,recurring,continual,continuous,steady,extensive,united,periodic,constant,enduring,immortal,lengthy,endless,everlasting,infinite,timeless,permanent,continuing,tall,deep,perennial,intermittent,eternal
 chang	china,prc
-venus	
 largo	composition,passage,piece,opus
 rogue	shady,sharp,fraudulent,fast,false,crooked,bent
-molly	
 jack	dollar,coin,change,tender,funds,green,money,gold,bucks,chips,dough,currency,bread,cabbage,cash,scratch
 goes	take,make,break,comes,come,fly,continue,lead,proceed,run,pass,work,does,move,leave,like,set,drop,happen,advances,fail,develop,retire,serve,allow,spend,fares,give,progress,finish,range,proceeds,flee,score,stand,turn,extend,travel,reach
-autism	
 habits	patterns,routines,nature,customs,morality,fashions,styles,spirit,presence,practices,ways,action,management,attitude,style,act,rituals,performance,modes,manners,role,tricks,conduct,practice,integrity,correctness,dignity,ideology
 piston	motor,instrument,appliance,cylinder,turbine,tool,transformer,generator,diesel,weapon
 hon	boyfriend,boy,dear,sweet,girlfriend,flame,beloved,lover,love,girl,sweetheart,husband,darling,squeeze,mistress,honey,wife
-le	
 vail	valley,dale,glen,hollow,canyon,gorge
 bottoms	feet,pasture,mud,prairie,floors,plain
 victoria	carriage,trap,rig,zambia,zimbabwe,diligence,coach,tandem,tonga,surrey,buggy,gig,stage,coupe,cab
@@ -15211,14 +14370,12 @@ pact	accord,deal,alliance,peace,settlement,transaction,protocol,treaty,understan
 portugal	nato,lisbon,ec,eu,porto,europe,portuguese
 undergraduate	reader,senior,sophomore,coed,student,freshman,scholar,postgraduate,junior,pupil
 manchester	nh
-tia	
 obstacle	chain,check,burden,obstruction,interference,constraint,restriction,hitch,stop,rub,block,inhibition,load,difficulty,barrier,let,hardship,handicap
 touches	hit,flair,kiss,strokes,tap,bit,eat,grips,mention,strike,ability,hand,feel,excite,approach,dash,familiarity,handle,inspire,technique,move,scent,upset,rub,communication,brush,feeling,pat,style,effect,consume,influence,holds,hint,taste,talent,lick,cover,contact,feels,stir,trace,fingers,hugs,impress,mark,stroke,detail,understanding,grab,lips,brushes,shade,involve,kisses,reach,skill,affect
 absent	removed,presence,gone,away,retired,lacking,missing,empty,out,vacant,unavailable
 acquiring	reception,admission,yes,occupation,lot,selection,seizure,control,gain,catching,store,compilation,getting,receipt,appropriation,compliance,act,set,acquisition,transaction,okay,procurement,recognition,consent,purchase,number,recovery,pickup,deed,assortment,ownership,capture,approval,permission,shopping,cooperation,possession,contracting,occupancy,accumulation,addition
 surrender	yield,deliver,delivery,leave,transfer,submit,quit,render,resign,commit,abandon,waive,submission
 flashlight	flash,flare,lighting,beacon,spotlight,lamp,torch,publicity,lantern,lighthouse,candle,chandelier,fame,light
-charles	
 brushes	arguments,encounters,fights
 after	past,following,afterwards,since,behind,subsequently,later,below
 smoking	urgent,dangerous,taking,severe,cigarette,succeeding,boiling,pull,tropical,warm,white,bombing,overcoming,significant,smoke,exceeding,licking,fiery,major,crop,finishing,mastering,tough,flaming,baking,furious,hot,scoring,beating,sweeping,fierce,meaningful,red,whipping,destroying,ventilation,enthusiastic,difficult,routing,throwing,deep,glowing,heated,important,overwhelming,raging,breathing,desperate,violent,puff
@@ -15235,7 +14392,6 @@ lam	run,getaway,break,escape,flee,rescue,flight,bunk,liberation,fly,slip,breakou
 bio	memory,chronicle,essay,letter,picture,story,profile,journal,diary,autobiography,sketch,life,memoir,biography,account,thesis,confession,note,narrative
 liquidity	flowing,fluid,diluted,thin
 dances	rock,waltz,disco,prom,celebrations,parties,samba,tango,events,balls,festivals
-walnut	
 cleavage	dispersion,split,partition,region,separation,distribution,polarization,division,decomposition,dissolution
 calcium	metal,ca,limestone,lime
 nerve	assurance,spirit,heart,determination,crust,confidence,stomach,brass,cheek,courage,sauce,face
@@ -15243,12 +14399,10 @@ disabilities	damages,hurts,defect,injuries,needs,impairment,injury
 habitat	range,surroundings,haven,nest,dwelling,niche,surround,terrain,cave,territory,environment,home,locality
 bur	hum,buzz,zoom,burr,whisper,sigh
 redhead	soul,person,individual,someone,somebody
-karaoke	
 hooded	thief,gorilla,criminal,thug,mug,punk,pirate,offender,tough
 dryer	arid,desert,baked,appliance
 mandated	charged,authorized,demanded,requested,called,asked,required,commanded,directed,ordered,assigned
 violence	struggle,disorder,clash,assault,rage,injury,riot,threat,cruelty,force,attack,fury,terrorism,aggression,battery,terror,pressure,confusion,damage,fighting,harm,disturbance,mayhem
-lutheran	
 amounts	measure,extent,lot,budget,load,sum,volume,cost,value,bulk,volumes,burden,ton,product,result,number,quantities,damage,portions,expense,output,supply,chunk,import
 capsules	caps,drugs,doses,tablets,medications,pills
 research	analyze,examination,inquiry,probe,investigating,inspection,microscopy,consult,study,probing,exploration,explore,probation,investigate,survey,investigation,analysis
@@ -15262,7 +14416,6 @@ learn	acquire,understand,absorb,grasp,enroll,hear,get,discover,see,receive,study
 front	frontal,presence,fore,forward,side,anterior,top,air,head,face
 plaque	stone,monument,badge,pillar,decoration,shrine,memorial,plate,medal,table,tablet,spot,marker,cross,slab
 impossible	absurd,unlikely,unreasonable,unacceptable,incredible,questionable,useless,outrageous,problematic,possibility
-broadway	
 accuracy	correctness,efficiency,certainty,perfection,inaccurate,accurate,fidelity,precision,truth,quality,skill
 ritz	flash
 wireless	telecom,telecommunication
@@ -15281,15 +14434,12 @@ offshore	coastal
 coca	bush
 generates	causes,make,does,effects,works,spawn,yields,cause,develop,produces,makes,brings,creates,prompts,achieve
 sadly	sharply,severely,hardly,hard
-hockey	
 causal	productive,innovative,creative,imaginative,constructive,unusual,influential
 remind	record,prompt,recall,advise,note,mind,retrieve,think,remember,emphasize,suggest,warn,raise,extract,mention,prod,stress,caution
-roc	
 moms	mothers
 abundant	rich,rank,thick,sufficient,heavy,quantity,liberal,easy,comfortable,ample,enough,galore,long,adequate,lush,plenty,generous
 raven	black,ebony,eat,exploit,fleece,dark,brunette
 ahead	shortly,earlier,along,forward,already,soon,early,now,before,previously,advanced
-welsh	
 printed	reprinted,issued,engraved,published,stamped,produced
 dominated	haunted,subjected,crushed,regulated,beat,defeated,troubled,reduced,controlled,supervised
 wont	custom,prone,accustomed,tradition,used
@@ -15299,7 +14449,6 @@ separated	removed,detached,distant,disconnected,divorced,separate,distinct
 dividing	allocation,arithmetic,identification,judgment,distribution,separation,estimation,splitting,pulling,prediction,counting,relation,testing,dissolution,similarity,example,segregation,resolving,connection,contrast,estimate,forecast,barrier,computation,analogy,correlation,ratio,separating,observation
 constituents	public,elements,factors,members,society,people,community,components,element,region,ingredients,material,state,thing,land
 acres	tract,manor,lot,area,countryside,nursery,equity,beach,premise,region,continent,nation,homestead,soil,plot,province,ground,acreage,field,park,terrain,meadow,worth,wealth,yard,campus,land,parcel,property,farm,pasture,ranch,earth,garden,backyard,plantation,realty,home,orchard,homeland,estate,house,shore,goods,ownership,country,territory,district,lawn
-br	
 rhythms	beats,pattern,drums,meters,pulse,accents,movement,flow,swing,tempo
 outback	countryside,country,frontier,bush
 ironic	unexpected,acid,humorous,dry,keen,twisted,cross,biting,ridiculous,sour
@@ -15345,7 +14494,6 @@ fiesta	carnival,gala,festival,feast,celebration,fest,jubilee
 sync	phase,adjust,conform,correct,correspond
 ccc	cardinal
 acceptance	accession,approval,consent,surrender,submission,recognition,conformity,adoption,compliance,cooperation,attitude,indulgence,admission,concession,agreement,obedience,compromise,reconciliation
-maharashtra	
 disco	club,saloon,bistro,cabaret,pub,nightclub,tavern,cafe
 lavender	lilac,violet
 collision	contact,punch,crash,slap,slam,jar,hit,shock,kick,bump,impact,strike,encounter,striking,smash,blow,knock,pounding
@@ -15353,7 +14501,6 @@ waterfall	water,falls,cascade,river
 pan	bucket,presence,aspect,mug,pot,face,features,appearance,sheet,looks,kettle,cookware,scan,wash
 involves	contain,comprise,concern,connect,cover,affect,suggest,require,engage,commit,catch,link,associate,affects,concerns,mean,hold,relate,prove,touches
 burn	shine,fire,boil,take,beam,char,torch,light,flame,rage,heat,beat,glow,blaze,melt,use
-pfc	
 woodworking	craft
 regs	instructions,standards,bylaws,guidelines,laws,regulations,rules,values,codes
 duties	service,rate,loyalty,work,tariffs,office,tariff,liability,accountability,charge,business,obligation,assessments,job,taxes,need,role,function,commission,levy,contract,commitment,task,burden
@@ -15366,7 +14513,6 @@ cushion	fender,mat,modify,padding,bumper,pad,buffer,shield
 screen	film,select,cinema,veil,monitor,hide,partition,evaluate,hollywood,movie,cover,display,shield,filter,scan,pictures
 painter	illustrator,artist,craftsman,artisan
 broncos	mounts,horse,colts,blacks,hacks,horses,chargers
-nudist	
 as	while,equally,since,because,whilst,similarly,when
 fashioned	suited,put,edited,intentional,conditioned,tailored,prepared,fit,adapted,customized,matched,modeled,shaped,fitted,adjusted,modified,altered
 plymouth	ma,massachusetts
@@ -15406,7 +14552,6 @@ married	united,joined,wed,marital
 cry	cheer,announce,declare,pipe,bark,scream,utter,call,yell,shout
 pedal	work,perform,tool,tone
 outlook	tower,expectation,forecast,viewpoint,direction,observatory,vision,opportunity,attitude,prospect,risk,possibility,lookout,perspective,chance
-guatemala	
 vets	veterans
 lottery	sweepstakes,numbers,gambling,drawing
 cooker	heater,lamp,toaster,stove,boiler,microwave,oven,cookware
@@ -15448,7 +14593,6 @@ weary	spent,done,beaten,exhausted,worn,bore,tire,fade,beat,sleepy,exhaust,bored,
 sounding	probe,loud,research,distinct,case,extent,analysis,study,search,hearing,survey,examination,depth,inquiry,inspection,review,draft,superficial,scrutiny,bottom,intensity
 examines	probe,inspect,vet,try,research,audit,study,measure,pumps,read,survey,scan,investigate,screen,consider,check,review,explore,view,questions
 blonde	mortal,white,someone,person,straw,somebody,sandy,golden,soul,individual
-chemotherapy	
 caregivers	protectors,guardians,nurses,carers
 shelving	cabinet,freeze,waive,secretary,suspend,dresser,wardrobe,chest
 rand	reef
@@ -15459,7 +14603,6 @@ darkness	secrecy,dark,despair,night,dusk,ignorance,shade,mystery,shadows,midnigh
 casual	cool,everyday,informal,relaxed,spontaneous,occasional
 tourism	business,travel
 coyote	courier,runner,mule
-homosexuality	
 pals	friends,brethren,buddies,sisters,partners,colleagues
 thick	dense,wide,opaque,muddy,abundant,dull,broad,massive,heavy,tight,fat,deep,hard,full,stiff,thickness
 lump	piece,bead,hunk,chunk,tumor,swelling,bump,knob,knot,pile
@@ -15472,9 +14615,6 @@ barn	shed
 speedway	track
 cancers	viruses,diseases,toxins
 motors	engines,machines,converters
-peptide	
-hart	
-presbyterian	
 transverse	cross,across
 aqueous	washed,rainy,moist,snowy,saturated,wet,damp,misty,slippery
 innings	turn,cricket
@@ -15507,7 +14647,6 @@ densities	thickness,consistency
 enquire	communicate,consult,ask
 proactive	careful,wise,forward,visionary,cautious,prudent
 bearings	looks,behaviors,conducts,attitudes,forms,characteristics,manners,styles,addresses,manner,traits,actions
-globalization	
 lost	wasted,hidden,dead,absorbed,unconscious,invisible,obsolete,missing,gone,forgotten,stray,absent
 then	formerly,yet,either,additionally,further,also,later,too,more,moreover,again,suddenly,next,furthermore,likewise,so,besides,thus
 fairy	troll,elf,imp,dwarf,gnome
@@ -15529,7 +14668,6 @@ visionary	noble,optimistic,windy,prophet,hopeful,romantic,ambitious,radical,ideo
 heck	mess,hell,chaos,confusion,disorder,havoc
 commercially	corporate
 vietnam	asean,vietnamese,hanoi
-refunds	
 administrative	regulatory,official,departmental,ministerial,managerial,legislative,governmental,executive,supervisory,organizational
 relieved	assured,confident,centered,sober,detached,satisfied,relaxed,bovine
 securities	bond,weapons,wealth,mortgage,guards,protections,walls,shields,balance,loan,wards,defenses,safeguards,screens,stock
@@ -15538,7 +14676,6 @@ historians	professor,writer,teacher
 architecture	shell,network,configuration,framing,skeleton,structure,engineering,composition,infrastructure,framework,construction,building,frame,planning,shape,fabric,style
 committing	realizing,executing,promise,doing,completing,engage,implementing,charge,act,finishing,give,fulfilling,violate,allocate,performing,do,invest,negotiating,making,offer,send,achieving,execute,hold
 analyses	study,inventories,interpretation,judgment,evaluations,classifications,test,inquiry,assays,reasoning,opinion,assessments,investigations,inspections,examinations,investigation,scrutiny,finding,summary,search,evaluation,report
-proudly	
 risks	exposure,prospect,possibility,danger,hazard,dangers,threats,hazards,compromise,liability,uncertainty,opportunity
 commentary	explanation,remark,exposition,note,description,criticism,analysis,critique,annotation,notation,report,observation,review,comment
 discount	forget,deduction,modify,slight,minimize,drop,rebate,concession,omit,reject,dismiss,doubt,premium,abatement,disregard,decrease,allowance,reduction,ignore,exemption,neglect
@@ -15600,7 +14737,6 @@ fostering	encouragement,facilitating,promoting,assisting,encouraging,forwarding
 stresses	strain,burden,tension,underline,anxiety,worries,trauma,strains,loads,hardship,concerns,heat,tensions,pressures,crunch,repeat,hassle,fear,worry,intensity
 cognition	power,process,lexicon,image,mind,reflection,vocabulary,operation,practice,abstraction,place,attitude,belief,observation,structure,ability,conviction,information,inability,thought,concept,prejudice,head,perception,idea,knowledge,conception,brain,nous,history,content,equivalent,impression
 bingo	lotto,poker,roulette
-guernsey	
 oasis	quarters,harbor,shelter,rest,housing,house,roof,port,anchorage,refuge,residence,sanctuary,screen,haven,asylum,dwelling,retreat
 located	situated,based,discovered,learned,placed,found,settled,detected,got,determined
 depart	fly,move,abandon,blow,exit,stray,quit,leave,get,part,retreat,flee,bail,skip,withdraw,retire,go,book,escape,start,disappear,remove
@@ -15616,7 +14752,6 @@ holy	religious,dedicated,divine,spiritual,sacred,pure,humble,blessed,sublime,rig
 zion	heaven,bliss,nirvana,glory,paradise,jerusalem,sky
 apex	vertex,height,crest,meridian,climax,extreme,zenith,crown,top,noon,peak,summit,head,sum,acme,pinnacle
 chapel	bethel,shrine,abbey,kirk,cathedral,mission,sanctuary,church,temple
-volleyball	
 glossary	listing,dictionary,lexicon,compilation,encyclopedia,vocabulary,bibliography,gloss,list,index,thesaurus
 nib	strain,edge,term,mouth,marker,particle,bill,fragment,smell,stick,point,taste,footprint,bird,indication,touch,element,proof,top,tone,hint,remains,deadline
 lessons	assignments,studies,readings,lectures,exercises


### PR DESCRIPTION
I ran a script against the synonyms to remove words that appear in this list: https://github.com/LDNOOBW/List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words/blob/master/en

But what's interesting is some of the words are (obviously) context dependent so we might want to keep them in. For example "cock" when referring to a rifle. So we could opt to keep those words, but if we do so, we need to add the source word back to the list of dictionary keys, too, otherwise we could introduce a dead end. 